### PR TITLE
Update C++ unittests to use custom Catch2 generators

### DIFF
--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -23,6 +23,15 @@ using Vec4 = ::math::Vector4<T>;
 template <typename T>
 using Mat2 = ::math::Matrix2<T>;
 
+template <typename T>
+using Mat3 = ::math::Matrix3<T>;
+
+template <typename T>
+using Mat4 = ::math::Matrix4<T>;
+
+template <typename T>
+using Quat = ::math::Quaternion<T>;
+
 template <typename T, typename V>
 class RandomValueBase : public Catch::Generators::IGenerator<V> {
  public:
@@ -162,12 +171,13 @@ auto random_vec4(T val_range_min = static_cast<T>(-1.0),
 }
 
 //****************************************************************************//
-//                       Generators for Matrix2 types                         //
+//                        Generators for Matrix types                         //
 //****************************************************************************//
 
 //-------------------//
 // Custom Generators //
 //-------------------//
+
 template <typename T>
 class RandomMatrix2Generator : public Catch::Generators::IGenerator<Mat2<T>> {
  public:
@@ -198,6 +208,86 @@ class RandomMatrix2Generator : public Catch::Generators::IGenerator<Mat2<T>> {
     Mat2<T> m_Value;
 };
 
+template <typename T>
+class RandomMatrix3Generator : public Catch::Generators::IGenerator<Mat3<T>> {
+ public:
+    RandomMatrix3Generator(T range_min, T range_max)
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(range_min, range_max) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Mat3<T>& override { return m_Value; }
+
+    auto next() -> bool override {
+        // Generate first column
+        m_Value(0, 0) = m_Dist(m_Gen);
+        m_Value(1, 0) = m_Dist(m_Gen);
+        m_Value(2, 0) = m_Dist(m_Gen);
+        // Generate second column
+        m_Value(0, 1) = m_Dist(m_Gen);
+        m_Value(1, 1) = m_Dist(m_Gen);
+        m_Value(2, 1) = m_Dist(m_Gen);
+        // Generate third column
+        m_Value(0, 2) = m_Dist(m_Gen);
+        m_Value(1, 2) = m_Dist(m_Gen);
+        m_Value(2, 2) = m_Dist(m_Gen);
+        return true;
+    }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Mat3<T> m_Value;
+};
+
+template <typename T>
+class RandomMatrix4Generator : public Catch::Generators::IGenerator<Mat4<T>> {
+ public:
+    RandomMatrix4Generator(T range_min, T range_max)
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(range_min, range_max) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Mat4<T>& override { return m_Value; }
+
+    auto next() -> bool override {
+        // Generate first column
+        m_Value(0, 0) = m_Dist(m_Gen);
+        m_Value(1, 0) = m_Dist(m_Gen);
+        m_Value(2, 0) = m_Dist(m_Gen);
+        m_Value(3, 0) = m_Dist(m_Gen);
+        // Generate second column
+        m_Value(0, 1) = m_Dist(m_Gen);
+        m_Value(1, 1) = m_Dist(m_Gen);
+        m_Value(2, 1) = m_Dist(m_Gen);
+        m_Value(3, 1) = m_Dist(m_Gen);
+        // Generate third column
+        m_Value(0, 2) = m_Dist(m_Gen);
+        m_Value(1, 2) = m_Dist(m_Gen);
+        m_Value(2, 2) = m_Dist(m_Gen);
+        m_Value(3, 2) = m_Dist(m_Gen);
+        // Generate fourth column
+        m_Value(0, 3) = m_Dist(m_Gen);
+        m_Value(1, 3) = m_Dist(m_Gen);
+        m_Value(2, 3) = m_Dist(m_Gen);
+        m_Value(3, 3) = m_Dist(m_Gen);
+        return true;
+    }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Mat4<T> m_Value;
+};
+
 //--------------------//
 // Generator wrappers //
 //--------------------//
@@ -211,105 +301,22 @@ auto random_mat2(T val_range_min = static_cast<T>(-1.0),
             val_range_min, val_range_max));
 }
 
-//****************************************************************************//
-//                       Generators for Matrix3 types //
-//****************************************************************************//
-
-//-------------------//
-// Custom Generators //
-//-------------------//
-
 template <typename T>
-class RandomMatrix3 : public RandomValueBase<T, Matrix3<T>> {
- public:
-    RandomMatrix3(T range_min, T range_max)
-        : RandomValueBase<T, Matrix3<T>>(range_min, range_max) {}
-
-    auto next() -> bool override {
-        this->m_Value =
-            Matrix3<T>(this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                       this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                       this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                       this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                       this->m_Dist(this->m_Gen));
-        return true;
-    }
-};
-
-template <typename T>
-class RandomRotationXMatrix3 : public RandomValueBase<T, Matrix3<T>> {
- public:
-    RandomRotationXMatrix3(T angle_min, T angle_max)
-        : RandomValueBase<T, Matrix3<T>>(angle_min, angle_max) {}
-
-    auto next() -> bool override {
-        this->m_Value = Matrix3<T>::RotationX(this->m_Dist(this->m_Gen));
-        return true;
-    }
-};
-
-template <typename T>
-class RandomRotationYMatrix3 : public RandomValueBase<T, Matrix3<T>> {
- public:
-    RandomRotationYMatrix3(T angle_min, T angle_max)
-        : RandomValueBase<T, Matrix3<T>>(angle_min, angle_max) {}
-
-    auto next() -> bool override {
-        this->m_Value = Matrix3<T>::RotationY(this->m_Dist(this->m_Gen));
-        return true;
-    }
-};
-
-template <typename T>
-class RandomRotationZMatrix3 : public RandomValueBase<T, Matrix3<T>> {
- public:
-    RandomRotationZMatrix3(T angle_min, T angle_max)
-        : RandomValueBase<T, Matrix3<T>>(angle_min, angle_max) {}
-
-    auto next() -> bool override {
-        this->m_Value = Matrix3<T>::RotationZ(this->m_Dist(this->m_Gen));
-        return true;
-    }
-};
-
-//--------------------//
-// Generator wrappers //
-//--------------------//
-
-template <typename T>
-auto random_mat3(T val_range_min = static_cast<T>(-10.0),
-                 T val_range_max = static_cast<T>(10.0))
-    -> Catch::Generators::GeneratorWrapper<Matrix3<T>> {
-    return Catch::Generators::GeneratorWrapper<Matrix3<T>>(
-        Catch::Generators::pf::make_unique<RandomMatrix3<T>>(val_range_min,
-                                                             val_range_max));
+auto random_mat3(T val_range_min = static_cast<T>(-1.0),
+                 T val_range_max = static_cast<T>(1.0))
+    -> Catch::Generators::GeneratorWrapper<Mat3<T>> {
+    return Catch::Generators::GeneratorWrapper<Mat3<T>>(
+        Catch::Generators::pf::make_unique<RandomMatrix3Generator<T>>(
+            val_range_min, val_range_max));
 }
 
 template <typename T>
-auto random_rotx_mat3(T angle_min = static_cast<T>(-::math::PI),
-                      T angle_max = static_cast<T>(::math::PI))
-    -> Catch::Generators::GeneratorWrapper<Matrix3<T>> {
-    return Catch::Generators::GeneratorWrapper<Matrix3<T>>(
-        Catch::Generators::pf::make_unique<RandomRotationXMatrix3<T>>(
-            angle_min, angle_max));
-}
-
-template <typename T>
-auto random_roty_mat3(T angle_min = static_cast<T>(-::math::PI),
-                      T angle_max = static_cast<T>(::math::PI))
-    -> Catch::Generators::GeneratorWrapper<Matrix3<T>> {
-    return Catch::Generators::GeneratorWrapper<Matrix3<T>>(
-        Catch::Generators::pf::make_unique<RandomRotationYMatrix3<T>>(
-            angle_min, angle_max));
-}
-
-template <typename T>
-auto random_rotz_mat3(T angle_min = static_cast<T>(-::math::PI),
-                      T angle_max = static_cast<T>(::math::PI))
-    -> Catch::Generators::GeneratorWrapper<Matrix3<T>> {
-    return Catch::Generators::GeneratorWrapper<Matrix3<T>>(
-        Catch::Generators::pf::make_unique<RandomRotationZMatrix3<T>>(
-            angle_min, angle_max));
+auto random_mat4(T val_range_min = static_cast<T>(-1.0),
+                 T val_range_max = static_cast<T>(1.0))
+    -> Catch::Generators::GeneratorWrapper<Mat4<T>> {
+    return Catch::Generators::GeneratorWrapper<Mat4<T>>(
+        Catch::Generators::pf::make_unique<RandomMatrix4Generator<T>>(
+            val_range_min, val_range_max));
 }
 
 //****************************************************************************//

--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -99,16 +99,31 @@ class RandomVec3Generator : public Catch::Generators::IGenerator<Vec3<T>> {
 };
 
 template <typename T>
-class RandomVec4Generator : public RandomValueBase<T, Vector4<T>> {
+class RandomVec4Generator : public Catch::Generators::IGenerator<Vec4<T>> {
  public:
-    RandomVec4Generator(T val_range_min, T val_range_max)
-        : RandomValueBase<T, Vector4<T>>(val_range_min, val_range_max) {}
+    RandomVec4Generator(T range_min, T range_max)
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(range_min, range_max) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Vec4<T>& override { return m_Value; }
 
     auto next() -> bool override {
-        this->m_Value = {this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                         this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen)};
+        m_Value.x() = m_Dist(m_Gen);
+        m_Value.y() = m_Dist(m_Gen);
+        m_Value.z() = m_Dist(m_Gen);
+        m_Value.w() = m_Dist(m_Gen);
         return true;
     }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Vec4<T> m_Value;
 };
 
 //--------------------//

--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -403,18 +403,31 @@ auto random_unit_quaternion() -> Catch::Generators::GeneratorWrapper<Quat<T>> {
 //-------------------//
 
 template <typename T>
-class RandomEuler : public RandomValueBase<T, Euler<T>> {
+class RandomEuler : public Catch::Generators::IGenerator<Euler<T>> {
  public:
     RandomEuler()
-        : RandomValueBase<T, Euler<T>>(static_cast<T>(-::math::PI),
-                                       static_cast<T>(::math::PI)) {}
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()),
+          m_Dist(static_cast<T>(-::math::PI), static_cast<T>(::math::PI)) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Euler<T>& override { return m_Value; }
 
     auto next() -> bool override {
-        this->m_Value.x = this->m_Dist(this->m_Gen);
-        this->m_Value.y = this->m_Dist(this->m_Gen);
-        this->m_Value.z = this->m_Dist(this->m_Gen);
+        m_Value.x = m_Dist(m_Gen);
+        m_Value.y = m_Dist(m_Gen);
+        m_Value.z = m_Dist(m_Gen);
         return true;
     }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Euler<T> m_Value;
 };
 
 //--------------------//

--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -10,6 +10,15 @@
 
 namespace math {
 
+template <typename T>
+using Vec2 = ::math::Vector2<T>;
+
+template <typename T>
+using Vec3 = ::math::Vector3<T>;
+
+template <typename T>
+using Vec4 = ::math::Vector4<T>;
+
 template <typename T, typename V>
 class RandomValueBase : public Catch::Generators::IGenerator<V> {
  public:
@@ -37,8 +46,7 @@ class RandomValueBase : public Catch::Generators::IGenerator<V> {
 //-------------------//
 
 template <typename T>
-class RandomVec2Generator
-    : public Catch::Generators::IGenerator<::math::Vector2<T>> {
+class RandomVec2Generator : public Catch::Generators::IGenerator<Vec2<T>> {
  public:
     RandomVec2Generator(T range_min, T range_max)
         // NOLINTNEXTLINE
@@ -46,7 +54,7 @@ class RandomVec2Generator
         static_cast<void>(next());
     }
 
-    auto get() const -> const ::math::Vector2<T>& override;
+    auto get() const -> const Vec2<T>& override { return m_Value; }
 
     auto next() -> bool override {
         m_Value.x() = m_Dist(m_Gen);
@@ -60,25 +68,34 @@ class RandomVec2Generator
     /// Distribution from which to generate random real values
     std::uniform_real_distribution<T> m_Dist;
     /// The random value to be exposed
-    ::math::Vector2<T> m_Value;
+    Vec2<T> m_Value;
 };
 
 template <typename T>
-auto RandomVec2Generator<T>::get() const -> const ::math::Vector2<T>& {
-    return m_Value;
-}
-
-template <typename T>
-class RandomVec3Generator : public RandomValueBase<T, Vector3<T>> {
+class RandomVec3Generator : public Catch::Generators::IGenerator<Vec3<T>> {
  public:
-    RandomVec3Generator(T val_range_min, T val_range_max)
-        : RandomValueBase<T, Vector3<T>>(val_range_min, val_range_max) {}
+    RandomVec3Generator(T range_min, T range_max)
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(range_min, range_max) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Vec3<T>& override { return m_Value; }
 
     auto next() -> bool override {
-        this->m_Value = {this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                         this->m_Dist(this->m_Gen)};
+        m_Value.x() = m_Dist(m_Gen);
+        m_Value.y() = m_Dist(m_Gen);
+        m_Value.z() = m_Dist(m_Gen);
         return true;
     }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Vec3<T> m_Value;
 };
 
 template <typename T>

--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -328,28 +328,54 @@ auto random_mat4(T val_range_min = static_cast<T>(-1.0),
 //-------------------//
 
 template <typename T>
-class RandomQuaternion : public RandomValueBase<T, Quaternion<T>> {
+class RandomQuaternion : public Catch::Generators::IGenerator<Quat<T>> {
  public:
-    RandomQuaternion() : RandomValueBase<T, Quaternion<T>>(-1.0, 1.0) {}
+    RandomQuaternion()
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(-1.0, 1.0) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Quat<T>& override { return m_Value; }
 
     auto next() -> bool override {
-        this->m_Value = {this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                         this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen)};
+        m_Value = {m_Dist(m_Gen), m_Dist(m_Gen), m_Dist(m_Gen), m_Dist(m_Gen)};
         return true;
     }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Quat<T> m_Value;
 };
 
 template <typename T>
-class RandomUnitQuaternion : public RandomValueBase<T, Quaternion<T>> {
+class RandomUnitQuaternion : public Catch::Generators::IGenerator<Quat<T>> {
  public:
-    RandomUnitQuaternion() : RandomValueBase<T, Quaternion<T>>(-1.0, 1.0) {}
+    RandomUnitQuaternion()
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(-1.0, 1.0) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Quat<T>& override { return m_Value; }
 
     auto next() -> bool override {
-        this->m_Value = {this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen),
-                         this->m_Dist(this->m_Gen), this->m_Dist(this->m_Gen)};
-        this->m_Value.normalize();
+        m_Value = {m_Dist(m_Gen), m_Dist(m_Gen), m_Dist(m_Gen), m_Dist(m_Gen)};
+        m_Value.normalize();
         return true;
     }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Quat<T> m_Value;
 };
 
 //--------------------//
@@ -357,15 +383,14 @@ class RandomUnitQuaternion : public RandomValueBase<T, Quaternion<T>> {
 //--------------------//
 
 template <typename T>
-auto random_quaternion() -> Catch::Generators::GeneratorWrapper<Quaternion<T>> {
-    return Catch::Generators::GeneratorWrapper<Quaternion<T>>(
+auto random_quaternion() -> Catch::Generators::GeneratorWrapper<Quat<T>> {
+    return Catch::Generators::GeneratorWrapper<Quat<T>>(
         Catch::Generators::pf::make_unique<RandomQuaternion<T>>());
 }
 
 template <typename T>
-auto random_unit_quaternion()
-    -> Catch::Generators::GeneratorWrapper<Quaternion<T>> {
-    return Catch::Generators::GeneratorWrapper<Quaternion<T>>(
+auto random_unit_quaternion() -> Catch::Generators::GeneratorWrapper<Quat<T>> {
+    return Catch::Generators::GeneratorWrapper<Quat<T>>(
         Catch::Generators::pf::make_unique<RandomUnitQuaternion<T>>());
 }
 

--- a/tests/cpp/common_math_generators.hpp
+++ b/tests/cpp/common_math_generators.hpp
@@ -2,9 +2,10 @@
 #include <math/vec2_t.hpp>
 #include <math/vec3_t.hpp>
 #include <math/vec4_t.hpp>
+#include <math/mat2_t.hpp>
 #include <math/mat3_t.hpp>
-#include <math/quat_t.hpp>
 #include <math/mat4_t.hpp>
+#include <math/quat_t.hpp>
 
 #include <random>
 
@@ -18,6 +19,9 @@ using Vec3 = ::math::Vector3<T>;
 
 template <typename T>
 using Vec4 = ::math::Vector4<T>;
+
+template <typename T>
+using Mat2 = ::math::Matrix2<T>;
 
 template <typename T, typename V>
 class RandomValueBase : public Catch::Generators::IGenerator<V> {
@@ -158,7 +162,57 @@ auto random_vec4(T val_range_min = static_cast<T>(-1.0),
 }
 
 //****************************************************************************//
-//                       Generators for Matrix3 types                         //
+//                       Generators for Matrix2 types                         //
+//****************************************************************************//
+
+//-------------------//
+// Custom Generators //
+//-------------------//
+template <typename T>
+class RandomMatrix2Generator : public Catch::Generators::IGenerator<Mat2<T>> {
+ public:
+    RandomMatrix2Generator(T range_min, T range_max)
+        // NOLINTNEXTLINE
+        : m_Gen(std::random_device{}()), m_Dist(range_min, range_max) {
+        static_cast<void>(next());
+    }
+
+    auto get() const -> const Mat2<T>& override { return m_Value; }
+
+    auto next() -> bool override {
+        // Generate first column
+        m_Value(0, 0) = m_Dist(m_Gen);
+        m_Value(1, 0) = m_Dist(m_Gen);
+        // Generate second column
+        m_Value(0, 1) = m_Dist(m_Gen);
+        m_Value(1, 1) = m_Dist(m_Gen);
+        return true;
+    }
+
+ private:
+    /// The method used to generate random numbers
+    std::minstd_rand m_Gen;
+    /// Distribution from which to generate random real values
+    std::uniform_real_distribution<T> m_Dist;
+    /// The random value to be exposed
+    Mat2<T> m_Value;
+};
+
+//--------------------//
+// Generator wrappers //
+//--------------------//
+
+template <typename T>
+auto random_mat2(T val_range_min = static_cast<T>(-1.0),
+                 T val_range_max = static_cast<T>(1.0))
+    -> Catch::Generators::GeneratorWrapper<Mat2<T>> {
+    return Catch::Generators::GeneratorWrapper<Mat2<T>>(
+        Catch::Generators::pf::make_unique<RandomMatrix2Generator<T>>(
+            val_range_min, val_range_max));
+}
+
+//****************************************************************************//
+//                       Generators for Matrix3 types //
 //****************************************************************************//
 
 //-------------------//

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -25,4 +25,12 @@ constexpr auto func_all_close(const ::math::Vector2<T>& vec, T x, T y, T eps)
            func_value_close(vec.y(), y, eps);
 }
 
+template <typename T>
+constexpr auto func_all_close(const ::math::Vector3<T>& vec, T x, T y, T z,
+                              T eps) -> bool {
+    return func_value_close(vec.x(), x, eps) &&
+           func_value_close(vec.y(), y, eps) &&
+           func_value_close(vec.z(), z, eps);
+}
+
 }  // namespace math

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -43,13 +43,61 @@ constexpr auto func_all_close(const ::math::Vector4<T>& vec, T x, T y, T z, T w,
            func_value_close(vec.w(), w, eps);
 }
 
+// clang-format off
 template <typename T>
-constexpr auto func_all_close(const ::math::Matrix2<T>& mat, T x00, T x01,
+constexpr auto func_all_close(const ::math::Matrix2<T>& mat,
+                              T x00, T x01,
                               T x10, T x11, T eps) -> bool {
     return func_value_close<T>(mat(0, 0), x00, eps) &&
            func_value_close<T>(mat(0, 1), x01, eps) &&
            func_value_close<T>(mat(1, 0), x10, eps) &&
            func_value_close<T>(mat(1, 1), x11, eps);
 }
+
+template <typename T>
+constexpr auto func_all_close(const ::math::Matrix3<T>& mat,
+                              T x00, T x01, T x02,
+                              T x10, T x11, T x12,
+                              T x20, T x21, T x22, T eps) -> bool {
+    return func_value_close<T>(mat(0, 0), x00, eps) &&
+           func_value_close<T>(mat(0, 1), x01, eps) &&
+           func_value_close<T>(mat(0, 2), x02, eps) &&
+
+           func_value_close<T>(mat(1, 0), x10, eps) &&
+           func_value_close<T>(mat(1, 1), x11, eps) &&
+           func_value_close<T>(mat(1, 2), x12, eps) &&
+
+           func_value_close<T>(mat(2, 0), x20, eps) &&
+           func_value_close<T>(mat(2, 1), x21, eps) &&
+           func_value_close<T>(mat(2, 2), x22, eps);
+}
+
+template <typename T>
+constexpr auto func_all_close(const ::math::Matrix4<T>& mat,
+                              T x00, T x01, T x02, T x03,
+                              T x10, T x11, T x12, T x13,
+                              T x20, T x21, T x22, T x23,
+                              T x30, T x31, T x32, T x33, T eps) -> bool {
+    return func_value_close<T>(mat(0, 0), x00, eps) &&
+           func_value_close<T>(mat(0, 1), x01, eps) &&
+           func_value_close<T>(mat(0, 2), x02, eps) &&
+           func_value_close<T>(mat(0, 3), x03, eps) &&
+
+           func_value_close<T>(mat(1, 0), x10, eps) &&
+           func_value_close<T>(mat(1, 1), x11, eps) &&
+           func_value_close<T>(mat(1, 2), x12, eps) &&
+           func_value_close<T>(mat(1, 3), x13, eps) &&
+
+           func_value_close<T>(mat(2, 0), x20, eps) &&
+           func_value_close<T>(mat(2, 1), x21, eps) &&
+           func_value_close<T>(mat(2, 2), x22, eps) &&
+           func_value_close<T>(mat(2, 3), x23, eps) &&
+
+           func_value_close<T>(mat(3, 0), x30, eps) &&
+           func_value_close<T>(mat(3, 1), x31, eps) &&
+           func_value_close<T>(mat(3, 2), x32, eps) &&
+           func_value_close<T>(mat(3, 3), x33, eps);
+}
+// clang-format on
 
 }  // namespace math

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -33,4 +33,13 @@ constexpr auto func_all_close(const ::math::Vector3<T>& vec, T x, T y, T z,
            func_value_close(vec.z(), z, eps);
 }
 
+template <typename T>
+constexpr auto func_all_close(const ::math::Vector4<T>& vec, T x, T y, T z, T w,
+                              T eps) -> bool {
+    return func_value_close(vec.x(), x, eps) &&
+           func_value_close(vec.y(), y, eps) &&
+           func_value_close(vec.z(), z, eps) &&
+           func_value_close(vec.w(), w, eps);
+}
+
 }  // namespace math

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -2,9 +2,10 @@
 #include <math/vec2_t.hpp>
 #include <math/vec3_t.hpp>
 #include <math/vec4_t.hpp>
+#include <math/mat2_t.hpp>
 #include <math/mat3_t.hpp>
-#include <math/quat_t.hpp>
 #include <math/mat4_t.hpp>
+#include <math/quat_t.hpp>
 
 // NOLINTNEXTLINE
 #define gen_random_value(T, range_min, range_max, Nsamples)   \
@@ -40,6 +41,15 @@ constexpr auto func_all_close(const ::math::Vector4<T>& vec, T x, T y, T z, T w,
            func_value_close(vec.y(), y, eps) &&
            func_value_close(vec.z(), z, eps) &&
            func_value_close(vec.w(), w, eps);
+}
+
+template <typename T>
+constexpr auto func_all_close(const ::math::Matrix2<T>& mat, T x00, T x01,
+                              T x10, T x11, T eps) -> bool {
+    return func_value_close<T>(mat(0, 0), x00, eps) &&
+           func_value_close<T>(mat(0, 1), x01, eps) &&
+           func_value_close<T>(mat(1, 0), x10, eps) &&
+           func_value_close<T>(mat(1, 1), x11, eps);
 }
 
 }  // namespace math

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -6,6 +6,8 @@
 #include <math/mat3_t.hpp>
 #include <math/mat4_t.hpp>
 #include <math/quat_t.hpp>
+#include <math/euler_t.hpp>
+#include "math/euler_t_decl.hpp"
 
 // NOLINTNEXTLINE
 #define gen_random_value(T, range_min, range_max, Nsamples)   \
@@ -107,6 +109,14 @@ constexpr auto func_all_close(const ::math::Quaternion<T>& quat, T w, T x, T y,
            func_value_close<T>(quat.x(), x, eps) &&
            func_value_close<T>(quat.y(), y, eps) &&
            func_value_close<T>(quat.z(), z, eps);
+}
+
+template <typename T>
+constexpr auto func_all_close(const ::math::Euler<T>& euler, T ex, T ey, T ez,
+                              T eps) -> bool {
+    return func_value_close<T>(euler.x, ex, eps) &&
+           func_value_close<T>(euler.y, ey, eps) &&
+           func_value_close<T>(euler.z, ez, eps);
 }
 
 }  // namespace math

--- a/tests/cpp/common_math_helpers.hpp
+++ b/tests/cpp/common_math_helpers.hpp
@@ -100,4 +100,13 @@ constexpr auto func_all_close(const ::math::Matrix4<T>& mat,
 }
 // clang-format on
 
+template <typename T>
+constexpr auto func_all_close(const ::math::Quaternion<T>& quat, T w, T x, T y,
+                              T z, T eps) -> bool {
+    return func_value_close<T>(quat.w(), w, eps) &&
+           func_value_close<T>(quat.x(), x, eps) &&
+           func_value_close<T>(quat.y(), y, eps) &&
+           func_value_close<T>(quat.z(), z, eps);
+}
+
 }  // namespace math

--- a/tests/cpp/test_mat2_functions.cpp
+++ b/tests/cpp/test_mat2_functions.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat2_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,75 +17,58 @@
 #pragma warning(disable : 4305)
 #endif
 
-static constexpr double ANGLE_MIN = -math::PI;
-static constexpr double ANGLE_MAX = math::PI;
+constexpr double USER_ANGLE_MIN = -::math::PI;
+constexpr double USER_ANGLE_MAX = ::math::PI;
+constexpr double USER_SCALE_MIN = -10.0;
+constexpr double USER_SCALE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
-// NOLINTNEXTLINE
-#define GenRandomAngle(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(ANGLE_MIN), \
-                                   static_cast<Type>(ANGLE_MAX))))
-
-static constexpr double SCALE_MIN = -10.0;
-static constexpr double SCALE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomScale(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(SCALE_MIN), \
-                                   static_cast<Type>(SCALE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-template <typename T>
-auto FuncAllClose(const math::Matrix2<T>& mat, T x00, T x01, T x10, T x11)
-    -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose(mat(0, 0), x00, EPSILON) &&
-           FuncClose(mat(0, 1), x01, EPSILON) &&
-           FuncClose(mat(1, 0), x10, EPSILON) &&
-           FuncClose(mat(1, 1), x11, EPSILON);
-}
+constexpr auto NUM_SAMPLES = 100;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix2 class (mat2_t) factory functions",
-                   "[mat2_t][funcs]", math::float32_t, math::float64_t) {
+                   "[mat2_t][funcs]", ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Matrix2 = math::Matrix2<T>;
-    using Vector2 = math::Vector2<T>;
+    using Matrix2 = ::math::Matrix2<T>;
+
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T ANGLE_MIN = static_cast<T>(USER_ANGLE_MIN);
+    constexpr T ANGLE_MAX = static_cast<T>(USER_ANGLE_MAX);
+    constexpr T SCALE_MIN = static_cast<T>(USER_SCALE_MIN);
+    constexpr T SCALE_MAX = static_cast<T>(USER_SCALE_MAX);
 
     SECTION("Rotation matrix") {
-        auto angle = GenRandomAngle(T, 100);
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix2::Rotation(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
             std::cos(angle), -std::sin(angle),
-            std::sin(angle), std::cos(angle)));
+            std::sin(angle),  std::cos(angle), EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from scalars") {
-        auto scale_x = GenRandomScale(T, 100);
-        auto scale_y = GenRandomScale(T, 100);
+        auto scale_x = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
+        auto scale_y = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
         auto scale_mat = Matrix2::Scale(scale_x, scale_y);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
             scale_x, 0.0,
-            0.0, scale_y));
+              0.0, scale_y, EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from vec2") {
-        auto scale = Vector2(GenRandomScale(T, 100), GenRandomScale(T, 100));
+        auto scale = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec2<T>(SCALE_MIN, SCALE_MAX)));
         auto scale_mat = Matrix2::Scale(scale);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
             scale.x(), 0.0,
-            0.0, scale.y()));
+            0.0, scale.y(), EPSILON));
         // clang-format on
     }
 }

--- a/tests/cpp/test_mat2_type.cpp
+++ b/tests/cpp/test_mat2_type.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat2_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,67 +17,99 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -10.0;
-constexpr double RANGE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-template <typename T>
-auto FuncAllClose(const math::Matrix2<T>& mat, T x00, T x01, T x10, T x11)
-    -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose(mat(0, 0), x00, EPSILON) &&
-           FuncClose(mat(0, 1), x01, EPSILON) &&
-           FuncClose(mat(1, 0), x10, EPSILON) &&
-           FuncClose(mat(1, 1), x11, EPSILON);
-}
+constexpr double USER_RANGE_MIN = -10.0;
+constexpr double USER_RANGE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix4 class (mat2_t) constructors", "[mat2_t][template]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Matrix2 = math::Matrix2<T>;
-    using Vector2 = math::Vector2<T>;
+    using Matrix2 = ::math::Matrix2<T>;
 
-    // Checking all exposed constructors
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
+
     SECTION("Default constructor") {
         Matrix2 mat;
-        REQUIRE(FuncAllClose<T>(mat, 0.0, 0.0, 0.0, 0.0));
+        // Default constructor creates zero-initialized matrix
+        // clang-format off
+        REQUIRE(::math::func_all_close<T>(mat,
+            0.0, 0.0,
+            0.0, 0.0, EPSILON));
+        // clang-format on
     }
+
     SECTION("From all matrix entries") {
-        auto x00 = GenRandomValue(T, 8);
-        auto x01 = GenRandomValue(T, 8);
-        auto x10 = GenRandomValue(T, 8);
-        auto x11 = GenRandomValue(T, 8);
+        constexpr auto NUM_SAMPLES = 4;
+        auto x00 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x01 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x10 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x11 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Matrix2 mat(x00, x01, x10, x11);
-        REQUIRE(FuncAllClose<T>(mat, x00, x01, x10, x11));
+        // clang-format off
+        REQUIRE(::math::func_all_close<T>(mat,
+            x00, x01,
+            x10, x11, EPSILON));
+        // clang-format on
     }
+
     SECTION("From diagonal entries") {
-        auto x00 = GenRandomValue(T, 8);
-        auto x11 = GenRandomValue(T, 8);
+        constexpr auto NUM_SAMPLES = 8;
+        auto x00 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x11 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Matrix2 mat(x00, x11);
-        REQUIRE(FuncAllClose<T>(mat, x00, 0.0, 0.0, x11));
+        // clang-format off
+        REQUIRE(::math::func_all_close<T>(mat,
+            x00, 0.0,
+            0.0, x11, EPSILON));
+        // clang-format on
     }
+
     SECTION("From column vectors") {
-        auto x00 = GenRandomValue(T, 8);
-        auto x01 = GenRandomValue(T, 8);
-        auto x10 = GenRandomValue(T, 8);
-        auto x11 = GenRandomValue(T, 8);
-        Vector2 col0(x00, x10);
-        Vector2 col1(x01, x11);
+        constexpr auto NUM_SAMPLES = 8;
+        auto col0 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec2<T>(RANGE_MIN, RANGE_MAX)));
+        auto col1 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec2<T>(RANGE_MIN, RANGE_MAX)));
 
         Matrix2 mat(col0, col1);
-        REQUIRE(FuncAllClose<T>(mat, x00, x01, x10, x11));
+        // clang-format off
+        REQUIRE(::math::func_all_close<T>(mat,
+            col0.x(), col1.x(),
+            col0.y(), col1.y(), EPSILON));
+        // clang-format on
+    }
+
+    SECTION("Accessor (i, j) returns scalar entry") {
+        Matrix2 mat;
+        // Update entries in first column
+        mat(0, 0) = 1.0;
+        mat(1, 0) = 2.0;
+        // Update entries in second column
+        mat(0, 1) = 3.0;
+        mat(1, 1) = 4.0;
+        // Make sure all entries are set accordingly
+        REQUIRE(::math::func_value_close<T>(mat(0, 0), 1.0, EPSILON));
+        REQUIRE(::math::func_value_close<T>(mat(1, 0), 2.0, EPSILON));
+        REQUIRE(::math::func_value_close<T>(mat(0, 1), 3.0, EPSILON));
+        REQUIRE(::math::func_value_close<T>(mat(1, 1), 4.0, EPSILON));
+    }
+
+    SECTION("Accessor [idx] returns column at index 'idx'") {
+        // clang-format off
+        Matrix2 mat(
+            1.0, 2.0,
+            3.0, 4.0);
+        // clang-format on
+        auto col0 = mat[0];
+        auto col1 = mat[1];
+        // Make sure we got the right column vectors from the matrix
+        REQUIRE(::math::func_all_close<T>(col0, 1.0, 3.0, EPSILON));
+        REQUIRE(::math::func_all_close<T>(col1, 2.0, 4.0, EPSILON));
     }
 }
 

--- a/tests/cpp/test_mat3_functions.cpp
+++ b/tests/cpp/test_mat3_functions.cpp
@@ -2,6 +2,9 @@
 #include <math/mat3_t.hpp>
 #include <math/quat_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -15,68 +18,36 @@
 #pragma warning(disable : 4305)
 #endif
 
-static constexpr double ANGLE_MIN = -math::PI;
-static constexpr double ANGLE_MAX = math::PI;
-
-// NOLINTNEXTLINE
-#define GenRandomAngle(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(ANGLE_MIN), \
-                                   static_cast<Type>(ANGLE_MAX))))
-
-static constexpr double SCALE_MIN = -10.0;
-static constexpr double SCALE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomScale(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(SCALE_MIN), \
-                                   static_cast<Type>(SCALE_MAX))))
-
-static constexpr double RANGE_MIN = -1.0;
-static constexpr double RANGE_MAX = 1.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-auto FuncAllClose(const math::Matrix3<T>& mat,
-                  T x00, T x01, T x02,
-                  T x10, T x11, T x12,
-                  T x20, T x21, T x22) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-
-    return FuncClose<T>(mat(0, 0), x00, EPSILON) &&
-           FuncClose<T>(mat(0, 1), x01, EPSILON) &&
-           FuncClose<T>(mat(0, 2), x02, EPSILON) &&
-           FuncClose<T>(mat(1, 0), x10, EPSILON) &&
-           FuncClose<T>(mat(1, 1), x11, EPSILON) &&
-           FuncClose<T>(mat(1, 2), x12, EPSILON) &&
-           FuncClose<T>(mat(2, 0), x20, EPSILON) &&
-           FuncClose<T>(mat(2, 1), x21, EPSILON) &&
-           FuncClose<T>(mat(2, 2), x22, EPSILON);
-}
-// clang-format on
+constexpr double USER_ANGLE_MIN = -math::PI;
+constexpr double USER_ANGLE_MAX = math::PI;
+constexpr double USER_SCALE_MIN = -10.0;
+constexpr double USER_SCALE_MAX = 10.0;
+constexpr double USER_RANGE_MIN = -10.0;
+constexpr double USER_RANGE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) factory functions",
-                   "[mat3_t][funcs]", math::float32_t, math::float64_t) {
+                   "[mat3_t][funcs]", ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Matrix3 = math::Matrix3<T>;
-    using Vector3 = math::Vector3<T>;
-    using Quaternion = math::Quaternion<T>;
+    using Matrix3 = ::math::Matrix3<T>;
+    using Quaternion = ::math::Quaternion<T>;
+
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T ANGLE_MIN = static_cast<T>(USER_ANGLE_MIN);
+    constexpr T ANGLE_MAX = static_cast<T>(USER_ANGLE_MAX);
+    constexpr T SCALE_MIN = static_cast<T>(USER_SCALE_MIN);
+    constexpr T SCALE_MAX = static_cast<T>(USER_SCALE_MAX);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     SECTION("Rotation matrix - from Quaternion") {
-        auto w = GenRandomValue(T, 4);
-        auto x = GenRandomValue(T, 4);
-        auto y = GenRandomValue(T, 4);
-        auto z = GenRandomValue(T, 4);
+        // TODO(wilbert): replace by random generator for quat
+        constexpr auto NUM_SAMPLES = 4;
+        auto w = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto z = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         auto quat = Quaternion(w, x, y, z);
         auto rot_mat = Matrix3(quat);
@@ -98,76 +69,79 @@ TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) factory functions",
         auto wx = w * x;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
-        // NOLINTNEXTLINE
+        REQUIRE(::math::func_all_close<T>(rot_mat,
         1.0 - 2.0 * (yy + zz),     2.0 * (xy - wz)   ,    2.0 * (xz + wy)   ,
-        // NOLINTNEXTLINE
             2.0 * (xy + wz)  , 1.0 - 2.0 * (xx + zz) ,    2.0 * (yz - wx)   ,
-        // NOLINTNEXTLINE
-            2.0 * (xz - wy)  ,     2.0 * (yz + wx)   , 1.0 - 2.0 * (xx + yy)));
+            2.0 * (xz - wy)  ,     2.0 * (yz + wx)   , 1.0 - 2.0 * (xx + yy),
+        EPSILON));
         // clang-format on
     }
 
     SECTION("Rotation matrix - X") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix3::RotationX(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
                 1.0,        0.0     ,       0.0       ,
                 0.0, std::cos(angle), -std::sin(angle),
-                0.0, std::sin(angle),  std::cos(angle)));
+                0.0, std::sin(angle),  std::cos(angle), EPSILON));
         // clang-format on
     }
 
     SECTION("Rotation matrix - Y") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix3::RotationY(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
                  std::cos(angle), 0.0, std::sin(angle),
                        0.0      , 1.0,       0.0      ,
-                -std::sin(angle), 0.0, std::cos(angle)));
+                -std::sin(angle), 0.0, std::cos(angle), EPSILON));
         // clang-format on
     }
 
     SECTION("Rotation matrix - Z") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix3::RotationZ(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
                 std::cos(angle), -std::sin(angle), 0.0,
                 std::sin(angle),  std::cos(angle), 0.0,
-                     0.0       ,        0.0      , 1.0));
+                     0.0       ,        0.0      , 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from scalars") {
-        auto scale_x = GenRandomScale(T, 10);
-        auto scale_y = GenRandomScale(T, 10);
-        auto scale_z = GenRandomScale(T, 10);
+        constexpr auto NUM_SAMPLES = 10;
+        auto scale_x = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
+        auto scale_y = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
+        auto scale_z = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
         auto scale_mat = Matrix3::Scale(scale_x, scale_y, scale_z);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
                 scale_x,   0.0  ,   0.0  ,
                     0.0, scale_y,   0.0  ,
-                    0.0,   0.0  , scale_z));
+                    0.0,   0.0  , scale_z, EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from vec3") {
-        auto scale = Vector3(GenRandomScale(T, 10), GenRandomScale(T, 10),
-                             GenRandomScale(T, 10));
+        constexpr auto NUM_SAMPLES = 10;
+        auto scale = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec3<T>(SCALE_MIN, SCALE_MAX)));
         auto scale_mat = Matrix3::Scale(scale);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
                 scale.x(),   0.0  ,   0.0  ,
                     0.0, scale.y(),   0.0  ,
-                    0.0,   0.0  , scale.z()));
+                    0.0,   0.0  , scale.z(), EPSILON));
         // clang-format on
     }
 }

--- a/tests/cpp/test_mat3_type.cpp
+++ b/tests/cpp/test_mat3_type.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat3_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,94 +17,69 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -100.0;
-constexpr double RANGE_MAX = 100.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-// NOLINTNEXTLINE
-#define GenRandomInRange(Type, Nsamples, range_min, range_max)   \
-    GENERATE(take(Nsamples, random(static_cast<Type>(range_min), \
-                                   static_cast<Type>(range_max))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-auto FuncAllClose(const math::Matrix3<T>& mat,
-                  T x00, T x01, T x02,
-                  T x10, T x11, T x12,
-                  T x20, T x21, T x22) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-
-    return FuncClose<T>(mat(0, 0), x00, EPSILON) &&
-           FuncClose<T>(mat(0, 1), x01, EPSILON) &&
-           FuncClose<T>(mat(0, 2), x02, EPSILON) &&
-           FuncClose<T>(mat(1, 0), x10, EPSILON) &&
-           FuncClose<T>(mat(1, 1), x11, EPSILON) &&
-           FuncClose<T>(mat(1, 2), x12, EPSILON) &&
-           FuncClose<T>(mat(2, 0), x20, EPSILON) &&
-           FuncClose<T>(mat(2, 1), x21, EPSILON) &&
-           FuncClose<T>(mat(2, 2), x22, EPSILON);
-}
-// clang-format on
+constexpr double USER_RANGE_MIN = -100.0;
+constexpr double USER_RANGE_MAX = 100.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) constructors", "[mat3_t][template]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Vec3 = math::Vector3<T>;
-    using Euler = math::Euler<T>;
-    using Mat3 = math::Matrix3<T>;
-    using Mat4 = math::Matrix4<T>;
-    using Quat = math::Quaternion<T>;
+    using Vec3 = ::math::Vector3<T>;
+    using Euler = ::math::Euler<T>;
+    using Mat3 = ::math::Matrix3<T>;
+    using Mat4 = ::math::Matrix4<T>;
+    using Quat = ::math::Quaternion<T>;
+
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     // Checking all exposed constructors
     SECTION("Default constructor") {
         Mat3 mat;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
-                0.0, 0.0, 0.0,
-                0.0, 0.0, 0.0,
-                0.0, 0.0, 0.0));
+        REQUIRE(::math::func_all_close<T>(mat,
+            0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From all matrix entries") {
         // clang-format off
         Mat3 mat(1.0, 2.0, 3.0,
-                    4.0, 5.0, 6.0,
-                    7.0, 8.0, 9.0);
+                 4.0, 5.0, 6.0,
+                 7.0, 8.0, 9.0);
 
-        REQUIRE(FuncAllClose<T>(mat,
-                1.0, 2.0, 3.0,
-                4.0, 5.0, 6.0,
-                7.0, 8.0, 9.0));
+        REQUIRE(::math::func_all_close<T>(mat,
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From diagonal entries") {
-        auto x00 = GenRandomValue(T, 8);
-        auto x11 = GenRandomValue(T, 8);
-        auto x22 = GenRandomValue(T, 8);
+        constexpr auto NUM_SAMPLES = 8;
+        auto x00 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x11 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x22 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Mat3 mat(x00, x11, x22);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
-                x00, 0.0, 0.0,
-                0.0, x11, 0.0,
-                0.0, 0.0, x22));
+        REQUIRE(::math::func_all_close<T>(mat,
+            x00, 0.0, 0.0,
+            0.0, x11, 0.0,
+            0.0, 0.0, x22, EPSILON));
         // clang-format on
     }
+
     SECTION("From column vectors") {
-        auto x00 = GenRandomValue(T, 8);
-        auto x11 = GenRandomValue(T, 8);
-        auto x22 = GenRandomValue(T, 8);
+        constexpr auto NUM_SAMPLES = 8;
+        auto x00 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x11 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x22 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Vec3 col0 = {x00, 2.0, 3.0};
         Vec3 col1 = {4.0, x11, 6.0};
@@ -110,26 +88,28 @@ TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) constructors", "[mat3_t][template]",
         Mat3 mat(col0, col1, col2);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
-                x00, 4.0, 7.0,
-                2.0, x11, 8.0,
-                3.0, 6.0, x22));
+        REQUIRE(::math::func_all_close<T>(mat,
+            x00, 4.0, 7.0,
+            2.0, x11, 8.0,
+            3.0, 6.0, x22, EPSILON));
         // clang-format on
     }
+
     SECTION("From quaternion") {
-        // NOLINTNEXTLINE
-        Quat q(1.0F, 0.0F, 0.0F, 0.0F);
+        Quat q(1.0, 0.0, 0.0, 0.0);
         Mat3 mat(q);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
+        REQUIRE(::math::func_all_close<T>(mat,
             1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
-            0.0, 0.0, 1.0));
+            0.0, 0.0, 1.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From Euler angles") {
-        auto theta = GenRandomInRange(T, 10, -::math::PI, ::math::PI);
+        constexpr auto NUM_SAMPLES = 8;
+        auto theta = gen_random_value(T, -::math::PI, ::math::PI, NUM_SAMPLES);
         auto cos_t = std::cos(theta);
         auto sin_t = std::sin(theta);
 
@@ -141,24 +121,26 @@ TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) constructors", "[mat3_t][template]",
         Mat3 mat_z(e_z);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_x,
-            1.0,  0.0 ,  0.0 ,
+        REQUIRE(::math::func_all_close<T>(mat_x,
+            1.0,  0.0 ,   0.0 ,
             0.0, cos_t, -sin_t,
-            0.0, sin_t, cos_t));
+            0.0, sin_t,  cos_t, EPSILON));
 
-        REQUIRE(FuncAllClose<T>(mat_y,
+        REQUIRE(::math::func_all_close<T>(mat_y,
             cos_t , 0.0,  sin_t ,
              0.0  , 1.0,   0.0  ,
-           -sin_t , 0.0,  cos_t));
+           -sin_t , 0.0,  cos_t , EPSILON));
 
-        REQUIRE(FuncAllClose<T>(mat_z,
+        REQUIRE(::math::func_all_close<T>(mat_z,
             cos_t , -sin_t , 0.0,
             sin_t ,  cos_t , 0.0,
-             0.0  ,   0.0  , 1.0));
+             0.0  ,   0.0  , 1.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From 4x4 transform matrix") {
-        auto theta = GenRandomInRange(T, 10, -::math::PI, ::math::PI);
+        constexpr auto NUM_SAMPLES = 8;
+        auto theta = gen_random_value(T, -::math::PI, ::math::PI, NUM_SAMPLES);
         auto cos_t = std::cos(theta);
         auto sin_t = std::sin(theta);
 
@@ -170,20 +152,20 @@ TEMPLATE_TEST_CASE("Matrix3 class (mat3_t) constructors", "[mat3_t][template]",
         Mat3 mat_z(tf_z);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_x,
-            1.0,  0.0 ,  0.0 ,
+        REQUIRE(::math::func_all_close<T>(mat_x,
+            1.0,  0.0 ,   0.0 ,
             0.0, cos_t, -sin_t,
-            0.0, sin_t, cos_t));
+            0.0, sin_t,  cos_t, EPSILON));
 
-        REQUIRE(FuncAllClose<T>(mat_y,
+        REQUIRE(::math::func_all_close<T>(mat_y,
             cos_t , 0.0,  sin_t ,
              0.0  , 1.0,   0.0  ,
-           -sin_t , 0.0,  cos_t));
+           -sin_t , 0.0,  cos_t , EPSILON));
 
-        REQUIRE(FuncAllClose<T>(mat_z,
+        REQUIRE(::math::func_all_close<T>(mat_z,
             cos_t , -sin_t , 0.0,
             sin_t ,  cos_t , 0.0,
-             0.0  ,   0.0  , 1.0));
+             0.0  ,   0.0  , 1.0, EPSILON));
         // clang-format on
     }
 }

--- a/tests/cpp/test_mat4_functions.cpp
+++ b/tests/cpp/test_mat4_functions.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat4_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,150 +17,113 @@
 #pragma warning(disable : 4305)
 #endif
 
-static constexpr auto ANGLE_MIN = -math::PI;
-static constexpr auto ANGLE_MAX = math::PI;
-
-// NOLINTNEXTLINE
-#define GenRandomAngle(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(ANGLE_MIN), \
-                                   static_cast<Type>(ANGLE_MAX))))
-
-static constexpr auto SCALE_MIN = -10.0;
-static constexpr auto SCALE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomScale(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(SCALE_MIN), \
-                                   static_cast<Type>(SCALE_MAX))))
-
-static constexpr auto RANGE_MIN = -100.0;
-static constexpr auto RANGE_MAX = 100.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-auto FuncAllClose(const math::Matrix4<T>& mat,
-                  T x00, T x01, T x02, T x03,
-                  T x10, T x11, T x12, T x13,
-                  T x20, T x21, T x22, T x23,
-                  T x30, T x31, T x32, T x33) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-
-    return FuncClose<T>(mat(0, 0), x00, EPSILON) &&
-           FuncClose<T>(mat(0, 1), x01, EPSILON) &&
-           FuncClose<T>(mat(0, 2), x02, EPSILON) &&
-           FuncClose<T>(mat(0, 3), x03, EPSILON) &&
-           FuncClose<T>(mat(1, 0), x10, EPSILON) &&
-           FuncClose<T>(mat(1, 1), x11, EPSILON) &&
-           FuncClose<T>(mat(1, 2), x12, EPSILON) &&
-           FuncClose<T>(mat(1, 3), x13, EPSILON) &&
-           FuncClose<T>(mat(2, 0), x20, EPSILON) &&
-           FuncClose<T>(mat(2, 1), x21, EPSILON) &&
-           FuncClose<T>(mat(2, 2), x22, EPSILON) &&
-           FuncClose<T>(mat(2, 3), x23, EPSILON) &&
-           FuncClose<T>(mat(3, 0), x30, EPSILON) &&
-           FuncClose<T>(mat(3, 1), x31, EPSILON) &&
-           FuncClose<T>(mat(3, 2), x32, EPSILON) &&
-           FuncClose<T>(mat(3, 3), x33, EPSILON);
-}
-// clang-format on
+constexpr double USER_ANGLE_MIN = -math::PI;
+constexpr double USER_ANGLE_MAX = math::PI;
+constexpr double USER_SCALE_MIN = -10.0;
+constexpr double USER_SCALE_MAX = 10.0;
+constexpr double USER_RANGE_MIN = -100.0;
+constexpr double USER_RANGE_MAX = 100.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) factory functions",
-                   "[mat4_t][funcs]", math::float32_t, math::float64_t) {
+                   "[mat4_t][funcs]", ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Matrix4 = math::Matrix4<T>;
-    using Vector3 = math::Vector3<T>;
+    using Matrix4 = ::math::Matrix4<T>;
+
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T ANGLE_MIN = static_cast<T>(USER_ANGLE_MIN);
+    constexpr T ANGLE_MAX = static_cast<T>(USER_ANGLE_MAX);
+    constexpr T SCALE_MIN = static_cast<T>(USER_SCALE_MIN);
+    constexpr T SCALE_MAX = static_cast<T>(USER_SCALE_MAX);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     SECTION("Rotation matrix -X") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix4::RotationX(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
                 1.0,        0.0     ,        0.0      , 0.0,
                 0.0, std::cos(angle), -std::sin(angle), 0.0,
                 0.0, std::sin(angle),  std::cos(angle), 0.0,
-                0.0,        0.0     ,        0.0      , 1.0));
-
+                0.0,        0.0     ,        0.0      , 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Rotation matrix - Y") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix4::RotationY(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
                 std::cos(angle), 0.0, std::sin(angle), 0.0,
                       0.0      , 1.0,       0.0      , 0.0,
                -std::sin(angle), 0.0, std::cos(angle), 0.0,
-                      0.0      , 0.0,       0.0      , 1.0));
+                      0.0      , 0.0,       0.0      , 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Rotation matrix - Z") {
-        auto angle = GenRandomAngle(T, 100);
+        constexpr auto NUM_SAMPLES = 100;
+        auto angle = gen_random_value(T, ANGLE_MIN, ANGLE_MAX, NUM_SAMPLES);
         auto rot_mat = Matrix4::RotationZ(angle);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(rot_mat,
+        REQUIRE(::math::func_all_close<T>(rot_mat,
             std::cos(angle), -std::sin(angle), 0.0, 0.0,
             std::sin(angle),  std::cos(angle), 0.0, 0.0,
                  0.0       ,        0.0      , 1.0, 0.0,
-                 0.0       ,        0.0      , 0.0, 1.0));
+                 0.0       ,        0.0      , 0.0, 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from scalars") {
-        auto scale_x = GenRandomScale(T, 10);
-        auto scale_y = GenRandomScale(T, 10);
-        auto scale_z = GenRandomScale(T, 10);
+        constexpr auto NUM_SAMPLES = 10;
+        auto scale_x = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
+        auto scale_y = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
+        auto scale_z = gen_random_value(T, SCALE_MIN, SCALE_MAX, NUM_SAMPLES);
         auto scale_mat = Matrix4::Scale(scale_x, scale_y, scale_z);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
                 scale_x,     0.0,     0.0, 0.0,
                     0.0, scale_y,     0.0, 0.0,
                     0.0,     0.0, scale_z, 0.0,
-                    0.0,     0.0,     0.0, 1.0));
+                    0.0,     0.0,     0.0, 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Scale matrix - from vec3") {
-        auto scale = Vector3(GenRandomScale(T, 10), GenRandomScale(T, 10),
-                             GenRandomScale(T, 10));
+        constexpr auto NUM_SAMPLES = 10;
+        auto scale = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec3<T>(SCALE_MIN, SCALE_MAX)));
         auto scale_mat = Matrix4::Scale(scale);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(scale_mat,
+        REQUIRE(::math::func_all_close<T>(scale_mat,
                 scale.x(),       0.0,       0.0, 0.0,
                       0.0, scale.y(),       0.0, 0.0,
                       0.0,       0.0, scale.z(), 0.0,
-                      0.0,       0.0,       0.0, 1.0));
+                      0.0,       0.0,       0.0, 1.0, EPSILON));
         // clang-format on
     }
 
     SECTION("Translation matrix - from vec3") {
-        auto position = Vector3(GenRandomValue(T, 10), GenRandomValue(T, 10),
-                                GenRandomValue(T, 10));
+        constexpr auto NUM_SAMPLES = 10;
+        auto position = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec3<T>(RANGE_MIN, RANGE_MAX)));
         auto translation_mat = Matrix4::Translation(position);
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(translation_mat,
+        REQUIRE(::math::func_all_close<T>(translation_mat,
                 1.0, 0.0, 0.0, position.x(),
                 0.0, 1.0, 0.0, position.y(),
                 0.0, 0.0, 1.0, position.z(),
-                0.0, 0.0, 0.0, 1.0));
+                0.0, 0.0, 0.0, 1.0, EPSILON));
         // clang-format on
     }
 }

--- a/tests/cpp/test_mat4_operations.cpp
+++ b/tests/cpp/test_mat4_operations.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat4_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,64 +17,22 @@
 #pragma warning(disable : 4305)
 #endif
 
-static constexpr double RANGE_MIN = -10.0;
-static constexpr double RANGE_MAX = 10.0;
+constexpr double USER_RANGE_MIN = -10.0;
+constexpr double USER_RANGE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
-// NOLINTNEXTLINE
-#define GenRandomValue(T, N) \
-    GENERATE(take(           \
-        N, random(static_cast<T>(RANGE_MIN), static_cast<T>(RANGE_MAX))));
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-auto FuncAllClose(const math::Matrix4<T>& mat,
-                  T x00, T x01, T x02, T x03,
-                  T x10, T x11, T x12, T x13,
-                  T x20, T x21, T x22, T x23,
-                  T x30, T x31, T x32, T x33) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-
-    return FuncClose<T>(mat(0, 0), x00, EPSILON) &&
-           FuncClose<T>(mat(0, 1), x01, EPSILON) &&
-           FuncClose<T>(mat(0, 2), x02, EPSILON) &&
-           FuncClose<T>(mat(0, 3), x03, EPSILON) &&
-           FuncClose<T>(mat(1, 0), x10, EPSILON) &&
-           FuncClose<T>(mat(1, 1), x11, EPSILON) &&
-           FuncClose<T>(mat(1, 2), x12, EPSILON) &&
-           FuncClose<T>(mat(1, 3), x13, EPSILON) &&
-           FuncClose<T>(mat(2, 0), x20, EPSILON) &&
-           FuncClose<T>(mat(2, 1), x21, EPSILON) &&
-           FuncClose<T>(mat(2, 2), x22, EPSILON) &&
-           FuncClose<T>(mat(2, 3), x23, EPSILON) &&
-           FuncClose<T>(mat(3, 0), x30, EPSILON) &&
-           FuncClose<T>(mat(3, 1), x31, EPSILON) &&
-           FuncClose<T>(mat(3, 2), x32, EPSILON) &&
-           FuncClose<T>(mat(3, 3), x33, EPSILON);
-}
-// clang-format on
-
-template <typename T>
-auto FuncAllClose(const math::Vector4<T>& vec, T x0, T x1, T x2, T x3) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose<T>(vec[0], x0, EPSILON) &&
-           FuncClose<T>(vec[1], x1, EPSILON) &&
-           FuncClose<T>(vec[2], x2, EPSILON) &&
-           FuncClose<T>(vec[3], x3, EPSILON);
-}
+constexpr auto NUM_SAMPLES = 10;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Matrix4 = math::Matrix4<T>;
-    using Vector4 = math::Vector4<T>;
+    using Matrix4 = ::math::Matrix4<T>;
+    using Vector4 = ::math::Vector4<T>;
 
-    constexpr T EPSILON = static_cast<T>(math::EPS);
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     SECTION("Matrix comparison ==, !=") {
         // clang-format off
@@ -79,119 +40,112 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
                     0.0, 2.0, 0.0, 0.0,
                     0.0, 0.0, 3.0, 0.0,
                     0.0, 0.0, 0.0, 4.0);
-        Matrix4 m_2(1.0, 2.0, 3.0, 4.0);
-        Matrix4 m_3(static_cast<T>(1.1),
-                    static_cast<T>(2.1),
-                    static_cast<T>(3.1),
-                    static_cast<T>(4.1));
         // clang-format on
+
+        Matrix4 m_2(1.0, 2.0, 3.0, 4.0);
+        Matrix4 m_3(1.1, 2.1, 3.1, 4.1);
+
         REQUIRE(m_1 == m_2);
         REQUIRE(m_2 != m_3);
         REQUIRE(m_3 != m_1);
     }
 
-    // Generate first random matrix (2^4 cases possible values)
-    auto x00 = GenRandomValue(T, 2);
-    auto x01 = GenRandomValue(T, 1);
-    auto x02 = GenRandomValue(T, 1);
-    auto x03 = GenRandomValue(T, 1);
+    // Generate first random matrix
+    const auto MAT_A = GENERATE(
+        take(NUM_SAMPLES, ::math::random_mat4<T>(RANGE_MIN, RANGE_MAX)));
+    // Generate second random matrix
+    const auto MAT_B = GENERATE(
+        take(NUM_SAMPLES, ::math::random_mat4<T>(RANGE_MIN, RANGE_MAX)));
 
-    auto x10 = GenRandomValue(T, 1);
-    auto x11 = GenRandomValue(T, 2);
-    auto x12 = GenRandomValue(T, 1);
-    auto x13 = GenRandomValue(T, 1);
+    // Get a handle of the entries of these matrices
+    auto x00 = MAT_A(0, 0);
+    auto x01 = MAT_A(0, 1);
+    auto x02 = MAT_A(0, 2);
+    auto x03 = MAT_A(0, 3);
 
-    auto x20 = GenRandomValue(T, 1);
-    auto x21 = GenRandomValue(T, 1);
-    auto x22 = GenRandomValue(T, 2);
-    auto x23 = GenRandomValue(T, 1);
+    auto x10 = MAT_A(1, 0);
+    auto x11 = MAT_A(1, 1);
+    auto x12 = MAT_A(1, 2);
+    auto x13 = MAT_A(1, 3);
 
-    auto x30 = GenRandomValue(T, 1);
-    auto x31 = GenRandomValue(T, 1);
-    auto x32 = GenRandomValue(T, 1);
-    auto x33 = GenRandomValue(T, 2);
+    auto x20 = MAT_A(2, 0);
+    auto x21 = MAT_A(2, 1);
+    auto x22 = MAT_A(2, 2);
+    auto x23 = MAT_A(2, 3);
 
-    // clang-format off
-    Matrix4 m_a(x00, x01, x02, x03,
-                x10, x11, x12, x13,
-                x20, x21, x22, x23,
-                x30, x31, x32, x33);
-    // clang-format on
+    auto x30 = MAT_A(3, 0);
+    auto x31 = MAT_A(3, 1);
+    auto x32 = MAT_A(3, 2);
+    auto x33 = MAT_A(3, 3);
 
-    // Generate second random matrix (2^8 cases possible values)
-    auto y00 = GenRandomValue(T, 2);
-    auto y10 = GenRandomValue(T, 1);
-    auto y01 = GenRandomValue(T, 1);
-    auto y11 = GenRandomValue(T, 1);
+    auto y00 = MAT_B(0, 0);
+    auto y01 = MAT_B(0, 1);
+    auto y02 = MAT_B(0, 2);
+    auto y03 = MAT_B(0, 3);
 
-    auto y02 = GenRandomValue(T, 1);
-    auto y12 = GenRandomValue(T, 2);
-    auto y03 = GenRandomValue(T, 1);
-    auto y13 = GenRandomValue(T, 1);
+    auto y10 = MAT_B(1, 0);
+    auto y11 = MAT_B(1, 1);
+    auto y12 = MAT_B(1, 2);
+    auto y13 = MAT_B(1, 3);
 
-    auto y20 = GenRandomValue(T, 1);
-    auto y30 = GenRandomValue(T, 1);
-    auto y21 = GenRandomValue(T, 2);
-    auto y31 = GenRandomValue(T, 1);
+    auto y20 = MAT_B(2, 0);
+    auto y21 = MAT_B(2, 1);
+    auto y22 = MAT_B(2, 2);
+    auto y23 = MAT_B(2, 3);
 
-    auto y22 = GenRandomValue(T, 1);
-    auto y32 = GenRandomValue(T, 1);
-    auto y23 = GenRandomValue(T, 1);
-    auto y33 = GenRandomValue(T, 2);
-
-    // clang-format off
-    Matrix4 m_b(y00, y01, y02, y03,
-                y10, y11, y12, y13,
-                y20, y21, y22, y23,
-                y30, y31, y32, y33);
-    // clang-format on
+    auto y30 = MAT_B(3, 0);
+    auto y31 = MAT_B(3, 1);
+    auto y32 = MAT_B(3, 2);
+    auto y33 = MAT_B(3, 3);
 
     SECTION("Matrix addition") {
-        auto mat_sum = m_a + m_b;
+        auto mat_sum = MAT_A + MAT_B;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_sum,
+        REQUIRE(::math::func_all_close<T>(mat_sum,
             x00 + y00, x01 + y01, x02 + y02, x03 + y03,
             x10 + y10, x11 + y11, x12 + y12, x13 + y13,
             x20 + y20, x21 + y21, x22 + y22, x23 + y23,
-            x30 + y30, x31 + y31, x32 + y32, x33 + y33));
+            x30 + y30, x31 + y31, x32 + y32, x33 + y33, EPSILON));
         // clang-format on
     }
     SECTION("Matrix substraction") {
-        auto mat_sub = m_a - m_b;
+        auto mat_sub = MAT_A - MAT_B;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_sub,
+        REQUIRE(::math::func_all_close<T>(mat_sub,
             x00 - y00, x01 - y01, x02 - y02, x03 - y03,
             x10 - y10, x11 - y11, x12 - y12, x13 - y13,
             x20 - y20, x21 - y21, x22 - y22, x23 - y23,
-            x30 - y30, x31 - y31, x32 - y32, x33 - y33));
+            x30 - y30, x31 - y31, x32 - y32, x33 - y33, EPSILON));
         // clang-format on
     }
     SECTION("Matrix-Scalar product") {
-        auto scale_1 = GenRandomValue(T, 1);
-        auto scale_2 = GenRandomValue(T, 1);
+        auto scale_1 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto scale_2 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
-        auto mat_scaled_1 = static_cast<double>(scale_1) * m_a;
-        auto mat_scaled_2 = m_b * static_cast<double>(scale_2);
+        auto mat_scaled_1 = scale_1 * MAT_A;
+        auto mat_scaled_2 = MAT_B * scale_2;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_scaled_1,
+        REQUIRE(::math::func_all_close<T>(mat_scaled_1,
             x00 * scale_1, x01 * scale_1, x02 * scale_1, x03 * scale_1,
             x10 * scale_1, x11 * scale_1, x12 * scale_1, x13 * scale_1,
             x20 * scale_1, x21 * scale_1, x22 * scale_1, x23 * scale_1,
-            x30 * scale_1, x31 * scale_1, x32 * scale_1, x33 * scale_1));
+            x30 * scale_1, x31 * scale_1, x32 * scale_1, x33 * scale_1,
+            EPSILON));
         // clang-format on
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_scaled_2,
+        REQUIRE(::math::func_all_close<T>(mat_scaled_2,
             y00 * scale_2, y01 * scale_2, y02 * scale_2, y03 * scale_2,
             y10 * scale_2, y11 * scale_2, y12 * scale_2, y13 * scale_2,
             y20 * scale_2, y21 * scale_2, y22 * scale_2, y23 * scale_2,
-            y30 * scale_2, y31 * scale_2, y32 * scale_2, y33 * scale_2));
+            y30 * scale_2, y31 * scale_2, y32 * scale_2, y33 * scale_2,
+            EPSILON));
         // clang-format on
     }
     SECTION("Matrix-Matrix product") {
         // clang-format off
-        // Fixed test-case
+        // Fixed test-case -------------------------------------
         Matrix4 m_1(-10.0, -6.0, -6.0,  2.0,
                     -8.0,  -6.0, -6.0, -5.0,
                      7.0, -10.0,  5.0,  7.0,
@@ -203,17 +157,18 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
                    -9.0,  2.0,  5.0, -3.0);
 
         auto mat_mul = m_1 * m_2;
-        REQUIRE(FuncAllClose<T>(mat_mul,
+        REQUIRE(::math::func_all_close<T>(mat_mul,
             -88.0, -60.0,  22.0, -42.0,
             -11.0, -60.0, -25.0, -15.0,
              91.0,  43.0, -87.0, -70.0,
-            -61.0,   5.0, -30.0, -37.0));
+            -61.0,   5.0, -30.0, -37.0, EPSILON));
+        // -----------------------------------------------------
         // clang-format on
 
-        // Test-cases using the random matrices
-        auto mat_mul_ab = m_a * m_b;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_mul_ab,
+        // Test-cases using the random matrices ----------------
+        auto mat_mul_ab = MAT_A * MAT_B;
+        REQUIRE(::math::func_all_close<T>(mat_mul_ab,
             // First row
             x00 * y00 + x01 * y10 + x02 * y20 + x03 * y30,
             x00 * y01 + x01 * y11 + x02 * y21 + x03 * y31,
@@ -233,13 +188,14 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
             x30 * y00 + x31 * y10 + x32 * y20 + x33 * y30,
             x30 * y01 + x31 * y11 + x32 * y21 + x33 * y31,
             x30 * y02 + x31 * y12 + x32 * y22 + x33 * y32,
-            x30 * y03 + x31 * y13 + x32 * y23 + x33 * y33));
+            x30 * y03 + x31 * y13 + x32 * y23 + x33 * y33, EPSILON));
+        // ----------------------------------------------------
         // clang-format on
         // @todo(wilbert): test with poorly conditioned matrices
     }
 
     SECTION("Matrix-Vector product") {
-        // Fixed test-case
+        // Fixed test-case --------------------------------------
         // clang-format off
         Matrix4 mat(9.0, 5.0,  9.0,  8.0,
                    -9.0, 1.0, -6.0,  8.0,
@@ -248,60 +204,64 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
         Vector4 vec(6.0, 7.0, -7.0, 5.0);
         // clang-format on
         auto mat_vec_mul_1 = mat * vec;
-        REQUIRE(FuncAllClose<T>(mat_vec_mul_1, 66.0, 35.0, -44.0, -30.0));
+        REQUIRE(::math::func_all_close<T>(mat_vec_mul_1, 66.0, 35.0, -44.0,
+                                          -30.0, EPSILON));
+        // ------------------------------------------------------
 
-        // Test-cases using the random matrices (reuse some random numbers)
-        auto v0 = GenRandomValue(T, 2);
-        auto v1 = GenRandomValue(T, 2);
-        auto v2 = GenRandomValue(T, 2);
-        auto v3 = GenRandomValue(T, 2);
-        Vector4 v_a(v0, v1, v2, v3);
-        auto mat_vec_mul_2 = m_a * v_a;
+        // Test-cases using the random matrices -----------------
+        auto v_a = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+
+        auto mat_vec_mul_2 = MAT_A * v_a;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_vec_mul_2,
-             x00 * v0 + x01 * v1 + x02 * v2 + x03 * v3,
-             x10 * v0 + x11 * v1 + x12 * v2 + x13 * v3,
-             x20 * v0 + x21 * v1 + x22 * v2 + x23 * v3,
-             x30 * v0 + x31 * v1 + x32 * v2 + x33 * v3));
+        REQUIRE(::math::func_all_close<T>(mat_vec_mul_2,
+             x00 * v_a.x() + x01 * v_a.y() + x02 * v_a.z() + x03 * v_a.w(),
+             x10 * v_a.x() + x11 * v_a.y() + x12 * v_a.z() + x13 * v_a.w(),
+             x20 * v_a.x() + x21 * v_a.y() + x22 * v_a.z() + x23 * v_a.w(),
+             x30 * v_a.x() + x31 * v_a.y() + x32 * v_a.z() + x33 * v_a.w(),
+             EPSILON));
         // clang-format on
+        // ------------------------------------------------------
     }
 
     SECTION("Element-wise matrix product") {
-        auto mat_elmwise = math::hadamard(m_a, m_b);
+        auto mat_elmwise = ::math::hadamard(MAT_A, MAT_B);
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat_elmwise,
+        REQUIRE(::math::func_all_close<T>(mat_elmwise,
             x00 * y00, x01 * y01, x02 * y02, x03 * y03,
             x10 * y10, x11 * y11, x12 * y12, x13 * y13,
             x20 * y20, x21 * y21, x22 * y22, x23 * y23,
-            x30 * y30, x31 * y31, x32 * y32, x33 * y33));
+            x30 * y30, x31 * y31, x32 * y32, x33 * y33, EPSILON));
         // clang-format on
     }
 
     SECTION("Matrix transposition") {
         // clang-format off
         // NOLINTNEXTLINE
-        REQUIRE(FuncAllClose<T>(math::transpose(m_a),
+        REQUIRE(::math::func_all_close<T>(::math::transpose(MAT_A),
             x00, x10, x20, x30,
             x01, x11, x21, x31,
             x02, x12, x22, x32,
-            x03, x13, x23, x33));
+            x03, x13, x23, x33, EPSILON));
         // NOLINTNEXTLINE
-        REQUIRE(FuncAllClose<T>(math::transpose(m_b),
+        REQUIRE(::math::func_all_close<T>(math::transpose(MAT_B),
             y00, y10, y20, y30,
             y01, y11, y21, y31,
             y02, y12, y22, y32,
-            y03, y13, y23, y33));
+            y03, y13, y23, y33, EPSILON));
         // clang-format on
     }
 
     SECTION("Matrix trace") {
-        auto calc_trace_1 = math::trace(m_a);
-        auto calc_trace_2 = math::trace(m_b);
+        auto calc_trace_1 = ::math::trace(MAT_A);
+        auto calc_trace_2 = ::math::trace(MAT_B);
         auto expected_trace_1 = x00 + x11 + x22 + x33;
         auto expected_trace_2 = y00 + y11 + y22 + y33;
 
-        REQUIRE(FuncClose<T>(calc_trace_1, expected_trace_1, EPSILON));
-        REQUIRE(FuncClose<T>(calc_trace_2, expected_trace_2, EPSILON));
+        REQUIRE(::math::func_value_close<T>(calc_trace_1, expected_trace_1,
+                                            EPSILON));
+        REQUIRE(::math::func_value_close<T>(calc_trace_2, expected_trace_2,
+                                            EPSILON));
     }
 
     SECTION("Matrix determinant") {
@@ -311,9 +271,9 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
                            2.0, 7.0, 8.0, 9.0,
                            6.0, 3.0, 4.0, 0.0);
         // clang-format on
-        auto calc_det = math::determinant(mat);
+        auto calc_det = ::math::determinant(mat);
         auto expected_det = static_cast<T>(885);
-        REQUIRE(FuncClose<T>(calc_det, expected_det, EPSILON));
+        REQUIRE(::math::func_value_close<T>(calc_det, expected_det, EPSILON));
     }
 
     SECTION("Matrix inverse") {
@@ -323,13 +283,13 @@ TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) core operations", "[mat4_t][ops]",
                            2.0, 7.0, 8.0, 9.0,
                            6.0, 3.0, 4.0, 0.0);
         // clang-format on
-        auto inv_mat = math::inverse(mat);
+        auto inv_mat = ::math::inverse(mat);
         // clang-format off
-        REQUIRE(FuncAllClose<T>(inv_mat,
+        REQUIRE(::math::func_all_close<T>(inv_mat,
             -0.019209, -0.174011,  0.150282,   0.119774,
             -0.232768, 0.0090395,  0.174011,  -0.019209,
               0.20339,  0.254237, -0.355932,  0.0847458,
-           0.00451977,  -0.19435,  0.258757, -0.0870056));
+           0.00451977,  -0.19435,  0.258757, -0.0870056, EPSILON));
         // clang-format on
     }
 }

--- a/tests/cpp/test_mat4_type.cpp
+++ b/tests/cpp/test_mat4_type.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/mat4_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,171 +17,140 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -10.0;
-constexpr double RANGE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))));
-
-// NOLINTNEXTLINE
-#define GenRandomInRange(Type, Nsamples, range_min, range_max)   \
-    GENERATE(take(Nsamples, random(static_cast<Type>(range_min), \
-                                   static_cast<Type>(range_max))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-auto FuncAllClose(const math::Matrix4<T>& mat,
-                  T x00, T x01, T x02, T x03,
-                  T x10, T x11, T x12, T x13,
-                  T x20, T x21, T x22, T x23,
-                  T x30, T x31, T x32, T x33) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-
-    return FuncClose<T>(mat(0, 0), x00, EPSILON) &&
-           FuncClose<T>(mat(0, 1), x01, EPSILON) &&
-           FuncClose<T>(mat(0, 2), x02, EPSILON) &&
-           FuncClose<T>(mat(0, 3), x03, EPSILON) &&
-           FuncClose<T>(mat(1, 0), x10, EPSILON) &&
-           FuncClose<T>(mat(1, 1), x11, EPSILON) &&
-           FuncClose<T>(mat(1, 2), x12, EPSILON) &&
-           FuncClose<T>(mat(1, 3), x13, EPSILON) &&
-           FuncClose<T>(mat(2, 0), x20, EPSILON) &&
-           FuncClose<T>(mat(2, 1), x21, EPSILON) &&
-           FuncClose<T>(mat(2, 2), x22, EPSILON) &&
-           FuncClose<T>(mat(2, 3), x23, EPSILON) &&
-           FuncClose<T>(mat(3, 0), x30, EPSILON) &&
-           FuncClose<T>(mat(3, 1), x31, EPSILON) &&
-           FuncClose<T>(mat(3, 2), x32, EPSILON) &&
-           FuncClose<T>(mat(3, 3), x33, EPSILON);
-}
-// clang-format on
+constexpr double USER_RANGE_MIN = -10.0;
+constexpr double USER_RANGE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Matrix4 class (mat4_t) constructors", "[mat4_t][template]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Vec3 = math::Vector3<T>;
-    using Vec4 = math::Vector4<T>;
-    using Euler = math::Euler<T>;
-    using Quat = math::Quaternion<T>;
-    using Mat3 = math::Matrix3<T>;
-    using Mat4 = math::Matrix4<T>;
+    using Euler = ::math::Euler<T>;
+    using Quat = ::math::Quaternion<T>;
+    using Mat3 = ::math::Matrix3<T>;
+    using Mat4 = ::math::Matrix4<T>;
+
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     // Checking all exposed constructors
     SECTION("Default constructor") {
         Mat4 mat;
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
+        REQUIRE(::math::func_all_close<T>(mat,
                 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0,
-                0.0, 0.0, 0.0, 0.0));
+                0.0, 0.0, 0.0, 0.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From all matrix entries") {
         // clang-format off
         Mat4 mat(1.0,  2.0,  3.0,  4.0,
-                    5.0,  6.0,  7.0,  8.0,
-                    9.0,  10.0, 11.0, 12.0,
-                    13.0, 14.0, 15.0, 16.0);
+                 5.0,  6.0,  7.0,  8.0,
+                 9.0,  10.0, 11.0, 12.0,
+                 13.0, 14.0, 15.0, 16.0);
 
-        REQUIRE(FuncAllClose<T>(mat,
+        REQUIRE(::math::func_all_close<T>(mat,
                 1.0,  2.0,  3.0,  4.0,
                 5.0,  6.0,  7.0,  8.0,
                 9.0,  10.0, 11.0, 12.0,
-                13.0, 14.0, 15.0, 16.0));
+                13.0, 14.0, 15.0, 16.0, EPSILON));
         // clang-format on
     }
+
     SECTION("From diagonal entries") {
-        auto x00 = GenRandomValue(T, 2);
-        auto x11 = GenRandomValue(T, 2);
-        auto x22 = GenRandomValue(T, 2);
-        auto x33 = GenRandomValue(T, 2);
+        constexpr auto NUM_SAMPLES = 2;
+        auto x00 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x11 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x22 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto x33 = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
         Mat4 mat(x00, x11, x22, x33);
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
+        REQUIRE(::math::func_all_close<T>(mat,
                 x00, 0.0, 0.0, 0.0,
                 0.0, x11, 0.0, 0.0,
                 0.0, 0.0, x22, 0.0,
-                0.0, 0.0, 0.0, x33));
+                0.0, 0.0, 0.0, x33, EPSILON));
         // clang-format on
     }
-    SECTION("From column vectors") {
-        auto x00 = GenRandomValue(T, 2);
-        auto x11 = GenRandomValue(T, 2);
-        auto x22 = GenRandomValue(T, 2);
-        auto x33 = GenRandomValue(T, 2);
 
-        Vec4 col0 = {x00, 2.0, 3.0, 4.0};
-        Vec4 col1 = {5.0, x11, 7.0, 8.0};
-        Vec4 col2 = {9.0, 10.0, x22, 12.0};
-        Vec4 col3 = {13.0, 14.0, 15.0, x33};
+    SECTION("From column vectors") {
+        constexpr auto NUM_SAMPLES = 2;
+        auto col0 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto col1 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto col2 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto col3 = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
         Mat4 mat(col0, col1, col2, col3);
         // clang-format off
-        REQUIRE(FuncAllClose<T>(mat,
-                x00, 5.0, 9.0,  13.0,
-                2.0, x11, 10.0, 14.0,
-                3.0, 7.0, x22,  15.0,
-                4.0, 8.0, 12.0, x33));
+        REQUIRE(::math::func_all_close<T>(mat,
+                col0.x(), col1.x(), col2.x(), col3.x(),
+                col0.y(), col1.y(), col2.y(), col3.y(),
+                col0.z(), col1.z(), col2.z(), col3.z(),
+                col0.w(), col1.w(), col2.w(), col3.w(), EPSILON));
         // clang-format on
     }
+
     SECTION("From position and orientation") {
-        auto pos_x = GenRandomValue(T, 2);
-        auto pos_y = GenRandomValue(T, 2);
-        auto pos_z = GenRandomValue(T, 2);
-        Vec3 position(pos_x, pos_y, pos_z);
+        constexpr auto NUM_SAMPLES = 8;
+        auto position = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec3<T>(RANGE_MIN, RANGE_MAX)));
 
         SECTION("Orientation given as a rotation matrix") {
-            auto angle = GenRandomInRange(T, 2, -math::PI, math::PI);
+            auto angle =
+                gen_random_value(T, -::math::PI, ::math::PI, NUM_SAMPLES);
             auto cos_t = std::cos(angle);
             auto sin_t = std::sin(angle);
             auto orientation = Mat3::RotationX(angle);
 
             Mat4 tf(position, orientation);
             // clang-format off
-            REQUIRE(FuncAllClose<T>(tf,
-                    1.0,  0.0 ,   0.0  , pos_x,
-                    0.0, cos_t, -sin_t , pos_y,
-                    0.0, sin_t,  cos_t , pos_z,
-                    0.0,  0.0 ,   0.0  , 1.0));
+            REQUIRE(::math::func_all_close<T>(tf,
+                    1.0,  0.0 ,   0.0  , position.x(),
+                    0.0, cos_t, -sin_t , position.y(),
+                    0.0, sin_t,  cos_t , position.z(),
+                    0.0,  0.0 ,   0.0  , 1.0, EPSILON));
             // clang-format on
         }
+
         SECTION("Orientation given as a quaternion") {
-            auto angle = GenRandomInRange(T, 2, -math::PI, math::PI);
+            auto angle =
+                gen_random_value(T, -::math::PI, ::math::PI, NUM_SAMPLES);
             auto cos_t = std::cos(angle);
             auto sin_t = std::sin(angle);
             auto orientation = Quat::RotationY(angle);
 
             Mat4 tf(position, orientation);
             // clang-format off
-            REQUIRE(FuncAllClose<T>(tf,
-                     cos_t , 0.0 , sin_t , pos_x,
-                      0.0  , 1.0 ,  0.0  , pos_y,
-                    -sin_t , 0.0 , cos_t , pos_z,
-                      0.0  , 0.0 ,  0.0  , 1.0));
+            REQUIRE(::math::func_all_close<T>(tf,
+                     cos_t , 0.0 , sin_t , position.x(),
+                      0.0  , 1.0 ,  0.0  , position.y(),
+                    -sin_t , 0.0 , cos_t , position.z(),
+                      0.0  , 0.0 ,  0.0  , 1.0, EPSILON));
             // clang-format on
         }
+
         SECTION("Orientation given as euler angles") {
-            auto angle = GenRandomInRange(T, 2, -math::PI, math::PI);
+            auto angle =
+                gen_random_value(T, -::math::PI, ::math::PI, NUM_SAMPLES);
             auto cos_t = std::cos(angle);
             auto sin_t = std::sin(angle);
             auto orientation = Euler(0.0, 0.0, angle);
 
             Mat4 tf(position, orientation);
             // clang-format off
-            REQUIRE(FuncAllClose<T>(tf,
-                    cos_t, -sin_t , 0.0 , pos_x,
-                    sin_t,  cos_t , 0.0 , pos_y,
-                     0.0 ,   0.0  , 1.0 , pos_z,
-                     0.0 ,   0.0  , 0.0 , 1.0));
+            REQUIRE(::math::func_all_close<T>(tf,
+                    cos_t, -sin_t , 0.0 , position.x(),
+                    sin_t,  cos_t , 0.0 , position.y(),
+                     0.0 ,   0.0  , 1.0 , position.z(),
+                     0.0 ,   0.0  , 0.0 , 1.0, EPSILON));
             // clang-format on
         }
     }

--- a/tests/cpp/test_quat_operations.cpp
+++ b/tests/cpp/test_quat_operations.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/quat_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,277 +17,190 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -10.0;
-constexpr double RANGE_MAX = 10.0;
-
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-// clang-format off
-template <typename T>
-constexpr auto FuncCompareEqual(T wa, T xa, T ya, T za,
-                                T wb, T xb, T yb, T zb,
-                                T eps) -> bool {
-    return FuncClose<T>(wa, wb, eps) && FuncClose<T>(ya, yb, eps) &&
-           FuncClose<T>(za, zb, eps) && FuncClose<T>(xa, xb, eps);
-}
-// clang-format on
-
-template <typename T>
-auto FuncAllClose(const math::Quaternion<T>& quat, T w, T x, T y, T z) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose<T>(quat.w(), w, EPSILON) &&
-           FuncClose<T>(quat.x(), x, EPSILON) &&
-           FuncClose<T>(quat.y(), y, EPSILON) &&
-           FuncClose<T>(quat.z(), z, EPSILON);
-}
+constexpr double USER_RANGE_MIN = -10.0;
+constexpr double USER_RANGE_MAX = 10.0;
+constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Quaternion class (quat_t) core Operations", "[quat_t][ops]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Quat = math::Quaternion<T>;
+    using Quat = ::math::Quaternion<T>;
     using Vec3 = ::math::Vector3<T>;
 
-    constexpr T EPSILON = static_cast<T>(math::EPS);
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     SECTION("Quaternion comparison ==, !=") {
-        // Checking a fixed test case ******************************************
         Quat q_1(4.0, 1.0, 2.0, 3.0);
         Quat q_2(4.0, 1.0, 2.0, 3.0);
-        Quat q_3(static_cast<T>(4.1), static_cast<T>(1.1), static_cast<T>(2.1),
-                 static_cast<T>(3.1));
+        Quat q_3(4.1, 1.1, 2.1, 3.1);
 
         REQUIRE(q_1 == q_2);
         REQUIRE(q_2 != q_3);
         REQUIRE(q_3 != q_1);
-
-        // Checking randomized test cases **************************************
-        auto val_w_a = GenRandomValue(T, 2);
-        auto val_x_a = GenRandomValue(T, 2);
-        auto val_y_a = GenRandomValue(T, 2);
-        auto val_z_a = GenRandomValue(T, 2);
-
-        auto val_w_b = GenRandomValue(T, 2);
-        auto val_x_b = GenRandomValue(T, 2);
-        auto val_y_b = GenRandomValue(T, 2);
-        auto val_z_b = GenRandomValue(T, 2);
-
-        Quat q_a(val_w_a, val_x_a, val_y_a, val_z_a);
-        Quat q_b(val_w_b, val_x_b, val_y_b, val_z_b);
-
-        auto equal_a_b_lib = (q_a == q_b);
-        // clang-format off
-        auto equal_a_b_man =
-            FuncCompareEqual<T>(val_w_a, val_x_a, val_y_a, val_z_a,
-                                val_w_b, val_x_b, val_y_b, val_z_b,
-                                EPSILON);
-        // clang-format on
-
-        auto diff_a_b_lib = (q_a != q_b);
-        auto diff_a_b_man = !equal_a_b_man;
-
-        REQUIRE(equal_a_b_lib == equal_a_b_man);
-        REQUIRE(diff_a_b_lib == diff_a_b_man);
     }
 
     SECTION("Quaternion addition") {
-        auto val_w_a = GenRandomValue(T, 2);
-        auto val_x_a = GenRandomValue(T, 2);
-        auto val_y_a = GenRandomValue(T, 2);
-        auto val_z_a = GenRandomValue(T, 2);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q_a = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        auto q_b = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
-        auto val_w_b = GenRandomValue(T, 2);
-        auto val_x_b = GenRandomValue(T, 2);
-        auto val_y_b = GenRandomValue(T, 2);
-        auto val_z_b = GenRandomValue(T, 2);
-
-        Quat q_a(val_w_a, val_x_a, val_y_a, val_z_a);
-        Quat q_b(val_w_b, val_x_b, val_y_b, val_z_b);
         auto q_sum = q_a + q_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(q_sum,
-                                val_w_a + val_w_b,
-                                val_x_a + val_x_b,
-                                val_y_a + val_y_b,
-                                val_z_a + val_z_b));
+        REQUIRE(::math::func_all_close<T>(q_sum,
+            q_a.w() + q_b.w(),
+            q_a.x() + q_b.x(),
+            q_a.y() + q_b.y(),
+            q_a.z() + q_b.z(), EPSILON));
         // clang-format on
     }
 
     SECTION("Quaternion substraction") {
-        auto val_w_a = GenRandomValue(T, 2);
-        auto val_x_a = GenRandomValue(T, 2);
-        auto val_y_a = GenRandomValue(T, 2);
-        auto val_z_a = GenRandomValue(T, 2);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q_a = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        auto q_b = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
-        auto val_w_b = GenRandomValue(T, 2);
-        auto val_x_b = GenRandomValue(T, 2);
-        auto val_y_b = GenRandomValue(T, 2);
-        auto val_z_b = GenRandomValue(T, 2);
-
-        Quat q_a(val_w_a, val_x_a, val_y_a, val_z_a);
-        Quat q_b(val_w_b, val_x_b, val_y_b, val_z_b);
-        auto q_sum = q_a - q_b;
+        auto q_diff = q_a - q_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(q_sum,
-                                val_w_a - val_w_b,
-                                val_x_a - val_x_b,
-                                val_y_a - val_y_b,
-                                val_z_a - val_z_b));
+        REQUIRE(::math::func_all_close<T>(q_diff,
+            q_a.w() - q_b.w(),
+            q_a.x() - q_b.x(),
+            q_a.y() - q_b.y(),
+            q_a.z() - q_b.z(), EPSILON));
         // clang-format on
     }
 
     SECTION("Quaternion product") {
-        auto a_w = GenRandomValue(T, 2);
-        auto a_x = GenRandomValue(T, 2);
-        auto a_y = GenRandomValue(T, 2);
-        auto a_z = GenRandomValue(T, 2);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q_a = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        auto q_b = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
-        auto b_w = GenRandomValue(T, 2);
-        auto b_x = GenRandomValue(T, 2);
-        auto b_y = GenRandomValue(T, 2);
-        auto b_z = GenRandomValue(T, 2);
-
-        Quat q_a(a_w, a_x, a_y, a_z);
-        Quat q_b(b_w, b_x, b_y, b_z);
         auto q_prod = q_a * q_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(q_prod,
-            a_w * b_w - a_x * b_x - a_y * b_y - a_z * b_z,
-            a_w * b_x + b_w * a_x + a_y * b_z - b_y * a_z,
-            a_w * b_y + b_w * a_y + a_z * b_x - b_z * a_x,
-            a_w * b_z + b_w * a_z + a_x * b_y - b_x * a_y));
+        REQUIRE(::math::func_all_close<T>(q_prod,
+            q_a.w() * q_b.w() - q_a.x() * q_b.x() -
+            q_a.y() * q_b.y() - q_a.z() * q_b.z(),
+            q_a.w() * q_b.x() + q_b.w() * q_a.x() +
+            q_a.y() * q_b.z() - q_b.y() * q_a.z(),
+            q_a.w() * q_b.y() + q_b.w() * q_a.y() +
+            q_a.z() * q_b.x() - q_b.z() * q_a.x(),
+            q_a.w() * q_b.z() + q_b.w() * q_a.z() +
+            q_a.x() * q_b.y() - q_b.x() * q_a.y(), EPSILON));
         // clang-format on
     }
 
     SECTION("Quaternion scale (by single scalar)") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto scale = GenRandomValue(T, 4);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        auto scale = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
-        Quat q(val_w, val_x, val_y, val_z);
-        auto q_1 = static_cast<double>(scale) * q;
-        auto q_2 = q * static_cast<double>(scale);
+        auto q_1 = scale * q;
+        auto q_2 = q * scale;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(q_1,
-                                val_w * scale,
-                                val_x * scale,
-                                val_y * scale,
-                                val_z * scale));
-        REQUIRE(FuncAllClose<T>(q_2,
-                                val_w * scale,
-                                val_x * scale,
-                                val_y * scale,
-                                val_z * scale));
+        REQUIRE(::math::func_all_close<T>(q_1,
+            q.w() * scale,
+            q.x() * scale,
+            q.y() * scale,
+            q.z() * scale, EPSILON));
+        REQUIRE(::math::func_all_close<T>(q_2,
+            q.w() * scale,
+            q.x() * scale,
+            q.y() * scale,
+            q.z() * scale, EPSILON));
         // clang-format on
     }
 
     SECTION("Quaternion length") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        Quat q(val_w, val_x, val_y, val_z);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
-        auto length = std::sqrt(val_w * val_w + val_x * val_x + val_y * val_y +
-                                val_z * val_z);
-        auto q_length = math::norm(q);
+        auto length = std::sqrt(q.w() * q.w() + q.x() * q.x() + q.y() * q.y() +
+                                q.z() * q.z());
+        auto q_length = ::math::norm(q);
 
         // TODO(wilbert): should check with small generated values as well. Most
         // of the values returned by the generator are quite large (their
         // squares)
 
-        if (math::IsFloat32<T>::value) {
+        if (::math::IsFloat32<T>::value) {
             // Use larger delta, as we're losing precision quickly on f32
-            REQUIRE(FuncClose<T>(q_length, length, static_cast<T>(1e-3)));
+            REQUIRE(::math::func_value_close<T>(q_length, length, 1e-3));
         } else {
-            REQUIRE(FuncClose<T>(q_length, length, EPSILON));
+            REQUIRE(::math::func_value_close<T>(q_length, length, EPSILON));
         }
     }
 
     SECTION("Quaternion normalization (in place)") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        Quat q(val_w, val_x, val_y, val_z);
-        math::normalize_in_place(q);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        // Compute the norm and normalize the quaternion manually
+        auto norm = std::sqrt(q.w() * q.w() + q.x() * q.x() + q.y() * q.y() +
+                              q.z() * q.z());
+        auto val_wnorm = q.w() / norm;
+        auto val_xnorm = q.x() / norm;
+        auto val_ynorm = q.y() / norm;
+        auto val_znorm = q.z() / norm;
 
-        auto norm = std::sqrt(val_w * val_w + val_x * val_x + val_y * val_y +
-                              val_z * val_z);
-        auto val_wnorm = val_w / norm;
-        auto val_xnorm = val_x / norm;
-        auto val_ynorm = val_y / norm;
-        auto val_znorm = val_z / norm;
+        // Normalize the quaternion and make sure it gives the expected result
+        ::math::normalize_in_place(q);
+        REQUIRE(::math::func_all_close<T>(q, val_wnorm, val_xnorm, val_ynorm,
+                                          val_znorm, EPSILON));
 
+        // Make sure the norm of the normalized quaternion is 1.0
         auto q_norm = math::norm(q);
-
-        REQUIRE(FuncClose<T>(q_norm, 1.0, EPSILON));
-        REQUIRE(FuncAllClose<T>(q, val_wnorm, val_xnorm, val_ynorm, val_znorm));
+        REQUIRE(::math::func_value_close<T>(q_norm, 1.0, EPSILON));
     }
 
     SECTION("Quaternion normalization (out-of place)") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        Quat q(val_w, val_x, val_y, val_z);
-        auto qn = math::normalize(q);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
+        // Compute the norm and normalize the quaternion manually
+        auto norm = std::sqrt(q.w() * q.w() + q.x() * q.x() + q.y() * q.y() +
+                              q.z() * q.z());
+        auto val_wnorm = q.w() / norm;
+        auto val_xnorm = q.x() / norm;
+        auto val_ynorm = q.y() / norm;
+        auto val_znorm = q.z() / norm;
 
-        auto norm = std::sqrt(val_w * val_w + val_x * val_x + val_y * val_y +
-                              val_z * val_z);
-        auto val_wnorm = val_w / norm;
-        auto val_xnorm = val_x / norm;
-        auto val_ynorm = val_y / norm;
-        auto val_znorm = val_z / norm;
+        // Normalize the quaternion and make sure it gives the expected result
+        auto qn = ::math::normalize(q);
+        REQUIRE(::math::func_all_close<T>(qn, val_wnorm, val_xnorm, val_ynorm,
+                                          val_znorm, EPSILON));
 
-        auto qn_norm = math::norm(qn);
-
-        REQUIRE(FuncClose<T>(qn_norm, 1.0, EPSILON));
-        REQUIRE(
-            FuncAllClose<T>(qn, val_wnorm, val_xnorm, val_ynorm, val_znorm));
+        // Make sure the norm of the normalized quaternion is 1.0
+        auto qn_norm = ::math::norm(qn);
+        REQUIRE(::math::func_value_close<T>(qn_norm, 1.0, EPSILON));
     }
 
     SECTION("Quaternion conjugate") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        Quat q(val_w, val_x, val_y, val_z);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
-        auto q_conj = math::conjugate<T>(q);
-        REQUIRE(FuncAllClose<T>(q_conj, val_w, -val_x, -val_y, -val_z));
+        auto q_conj = ::math::conjugate<T>(q);
+        REQUIRE(::math::func_all_close<T>(q_conj, q.w(), -q.x(), -q.y(), -q.z(),
+                                          EPSILON));
     }
 
     SECTION("Quaternion inverse") {
-        auto val_w = GenRandomValue(T, 4);
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        Quat q(val_w, val_x, val_y, val_z);
+        constexpr auto NUM_SAMPLES = 10;
+        auto q = GENERATE(take(NUM_SAMPLES, ::math::random_quaternion<T>()));
 
         auto length_sq =
-            val_w * val_w + val_x * val_x + val_y * val_y + val_z * val_z;
-        auto qinv_w = val_w / length_sq;
-        auto qinv_x = -val_x / length_sq;
-        auto qinv_y = -val_y / length_sq;
-        auto qinv_z = -val_z / length_sq;
+            q.w() * q.w() + q.x() * q.x() + q.y() * q.y() + q.z() * q.z();
+        auto qinv_w = q.w() / length_sq;
+        auto qinv_x = -q.x() / length_sq;
+        auto qinv_y = -q.y() / length_sq;
+        auto qinv_z = -q.z() / length_sq;
 
-        auto q_inv = math::inverse<T>(q);
-        REQUIRE(FuncAllClose<T>(q_inv, qinv_w, qinv_x, qinv_y, qinv_z));
+        auto q_inv = ::math::inverse<T>(q);
+        REQUIRE(::math::func_all_close<T>(q_inv, qinv_w, qinv_x, qinv_y, qinv_z,
+                                          EPSILON));
     }
 
     SECTION("Quaternion as rotations") {
@@ -293,9 +209,9 @@ TEMPLATE_TEST_CASE("Quaternion class (quat_t) core Operations", "[quat_t][ops]",
         Vec3 vec_j(0.0, 1.0, 0.0);
         Vec3 vec_k(0.0, 0.0, 1.0);
 
-        auto q_x = Quat::RotationX(static_cast<T>(::math::PI / 2.0));
-        auto q_y = Quat::RotationY(static_cast<T>(::math::PI / 2.0));
-        auto q_z = Quat::RotationZ(static_cast<T>(::math::PI / 2.0));
+        auto q_x = Quat::RotationX(::math::PI / 2.0);
+        auto q_y = Quat::RotationY(::math::PI / 2.0);
+        auto q_z = Quat::RotationZ(::math::PI / 2.0);
 
         REQUIRE(vec_j == ::math::rotate<T>(q_z, vec_i));
         REQUIRE(vec_k == ::math::rotate<T>(q_x, vec_j));

--- a/tests/cpp/test_vec2_type.cpp
+++ b/tests/cpp/test_vec2_type.cpp
@@ -22,9 +22,9 @@ constexpr double USER_EPSILON = 1e-5;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Vector2 class (vec2_t) type", "[vec2_t][template]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Vector2 = math::Vector2<T>;
+    using Vector2 = ::math::Vector2<T>;
 
     constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
     constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);

--- a/tests/cpp/test_vec4_operations.cpp
+++ b/tests/cpp/test_vec4_operations.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch.hpp>
 #include <math/vec4_t.hpp>
 
+#include "./common_math_helpers.hpp"
+#include "./common_math_generators.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,280 +17,198 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -100.0;
-constexpr double RANGE_MAX = 100.0;
+constexpr double USER_RANGE_MIN = -1000.0;
+constexpr double USER_RANGE_MAX = 1000.0;
+constexpr double USER_EPSILON = 1e-5;
 
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-template <typename T>
-constexpr auto FuncCompareEqual(T xa, T ya, T za, T xb, T yb, T zb, T wa, T wb,
-                                T eps) -> bool {
-    return FuncClose<T>(xa, xb, eps) && FuncClose<T>(ya, yb, eps) &&
-           FuncClose<T>(za, zb, eps) && FuncClose<T>(wa, wb, eps);
-}
-
-template <typename T>
-auto FuncAllClose(const math::Vector4<T>& vec, T x, T y, T z, T w) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose<T>(vec.x(), x, EPSILON) &&
-           FuncClose<T>(vec.y(), y, EPSILON) &&
-           FuncClose<T>(vec.z(), z, EPSILON) &&
-           FuncClose<T>(vec.w(), w, EPSILON);
-}
+constexpr auto NUM_SAMPLES = 10;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Vector4 class (vec4_t) core Operations", "[vec4_t][ops]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Vector4 = math::Vector4<T>;
+    using Vector4 = ::math::Vector4<T>;
 
-    constexpr T EPSILON = static_cast<T>(math::EPS);
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
 
     SECTION("Vector comparison ==, !=") {
-        Vector4 v_1(1.0, 2.0, 3.0, 4.0);                        // NOLINT
-        Vector4 v_2(1.0, 2.0, 3.0, 4.0);                        // NOLINT
-        Vector4 v_3(static_cast<T>(1.1), static_cast<T>(2.1),   // NOLINT
-                    static_cast<T>(3.1), static_cast<T>(4.1));  // NOLINT
+        Vector4 v_1(1.0, 2.0, 3.0, 4.0);
+        Vector4 v_2(1.0, 2.0, 3.0, 4.0);
+        Vector4 v_3(1.1, 2.1, 3.1, 4.1);
 
         REQUIRE(v_1 == v_2);
         REQUIRE(v_2 != v_3);
         REQUIRE(v_3 != v_1);
-
-        auto val_x_a = GenRandomValue(T, 2);
-        auto val_y_a = GenRandomValue(T, 2);
-        auto val_z_a = GenRandomValue(T, 2);
-        auto val_w_a = GenRandomValue(T, 2);
-
-        auto val_x_b = GenRandomValue(T, 2);
-        auto val_y_b = GenRandomValue(T, 2);
-        auto val_z_b = GenRandomValue(T, 2);
-        auto val_w_b = GenRandomValue(T, 2);
-
-        Vector4 v_a(val_x_a, val_y_a, val_z_a, val_w_a);
-        Vector4 v_b(val_x_b, val_y_b, val_z_b, val_w_b);
-
-        auto equal_a_b_lib = (v_a == v_b);
-        auto equal_a_b_man =
-            FuncCompareEqual<T>(val_x_a, val_y_a, val_z_a, val_x_b, val_y_b,
-                                val_z_b, val_w_a, val_w_b, EPSILON);
-
-        auto diff_a_b_lib = (v_a != v_b);
-        auto diff_a_b_man = !equal_a_b_man;
-
-        REQUIRE(equal_a_b_lib == equal_a_b_man);
-        REQUIRE(diff_a_b_lib == diff_a_b_man);
     }
 
     SECTION("Vector addition") {
-        auto val_x_a = GenRandomValue(T, 4);
-        auto val_y_a = GenRandomValue(T, 4);
-        auto val_z_a = GenRandomValue(T, 4);
-        auto val_w_a = GenRandomValue(T, 4);
+        auto v_a = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto v_b = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
-        auto val_x_b = GenRandomValue(T, 4);
-        auto val_y_b = GenRandomValue(T, 4);
-        auto val_z_b = GenRandomValue(T, 4);
-        auto val_w_b = GenRandomValue(T, 4);
-
-        Vector4 v_a(val_x_a, val_y_a, val_z_a, val_w_a);
-        Vector4 v_b(val_x_b, val_y_b, val_z_b, val_w_b);
         auto v_result = v_a + v_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(v_result,
-                                val_x_a + val_x_b,
-                                val_y_a + val_y_b,
-                                val_z_a + val_z_b,
-                                val_w_a + val_w_b));
+        REQUIRE(::math::func_all_close<T>(v_result,
+            v_a.x() + v_b.x(),
+            v_a.y() + v_b.y(),
+            v_a.z() + v_b.z(),
+            v_a.w() + v_b.w(), EPSILON));
         // clang-format on
     }
 
     SECTION("Vector substraction") {
-        auto val_x_a = GenRandomValue(T, 4);
-        auto val_y_a = GenRandomValue(T, 4);
-        auto val_z_a = GenRandomValue(T, 4);
-        auto val_w_a = GenRandomValue(T, 4);
+        auto v_a = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto v_b = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
-        auto val_x_b = GenRandomValue(T, 4);
-        auto val_y_b = GenRandomValue(T, 4);
-        auto val_z_b = GenRandomValue(T, 4);
-        auto val_w_b = GenRandomValue(T, 4);
-
-        Vector4 v_a(val_x_a, val_y_a, val_z_a, val_w_a);
-        Vector4 v_b(val_x_b, val_y_b, val_z_b, val_w_b);
         auto v_result = v_a - v_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(v_result,
-                                val_x_a - val_x_b,
-                                val_y_a - val_y_b,
-                                val_z_a - val_z_b,
-                                val_w_a - val_w_b));
+        REQUIRE(::math::func_all_close<T>(v_result,
+            v_a.x() - v_b.x(),
+            v_a.y() - v_b.y(),
+            v_a.z() - v_b.z(),
+            v_a.w() - v_b.w(), EPSILON));
         // clang-format on
     }
 
     SECTION("Vector element-wise product") {
-        auto val_x_a = GenRandomValue(T, 4);
-        auto val_y_a = GenRandomValue(T, 4);
-        auto val_z_a = GenRandomValue(T, 4);
-        auto val_w_a = GenRandomValue(T, 4);
+        auto v_a = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto v_b = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
-        auto val_x_b = GenRandomValue(T, 4);
-        auto val_y_b = GenRandomValue(T, 4);
-        auto val_z_b = GenRandomValue(T, 4);
-        auto val_w_b = GenRandomValue(T, 4);
-
-        Vector4 v_a(val_x_a, val_y_a, val_z_a, val_w_a);
-        Vector4 v_b(val_x_b, val_y_b, val_z_b, val_w_b);
         auto v_result = v_a * v_b;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(v_result,
-                                val_x_a * val_x_b,
-                                val_y_a * val_y_b,
-                                val_z_a * val_z_b,
-                                val_w_a * val_w_b));
+        REQUIRE(::math::func_all_close<T>(v_result,
+            v_a.x() * v_b.x(),
+            v_a.y() * v_b.y(),
+            v_a.z() * v_b.z(),
+            v_a.w() * v_b.w(), EPSILON));
         // clang-format on
     }
 
     SECTION("Vector scale (by single scalar)") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
-        auto scale = GenRandomValue(T, 4);
+        auto v = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto scale = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
-        Vector4 v(val_x, val_y, val_z, val_w);
-        auto v_1 = static_cast<double>(scale) * v;
-        auto v_2 = v * static_cast<double>(scale);
+        auto v_1 = scale * v;
+        auto v_2 = v * scale;
 
         // clang-format off
-        REQUIRE(FuncAllClose<T>(v_1,
-                                val_x * scale,
-                                val_y * scale,
-                                val_z * scale,
-                                val_w * scale));
-        REQUIRE(FuncAllClose<T>(v_2,
-                                val_x * scale,
-                                val_y * scale,
-                                val_z * scale,
-                                val_w * scale));
+        REQUIRE(::math::func_all_close<T>(v_1,
+            v.x() * scale,
+            v.y() * scale,
+            v.z() * scale,
+            v.w() * scale, EPSILON));
+        REQUIRE(::math::func_all_close<T>(v_2,
+            v.x() * scale,
+            v.y() * scale,
+            v.z() * scale,
+            v.w() * scale, EPSILON));
         // clang-format on
     }
 
     SECTION("Vector length") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
-        Vector4 v(val_x, val_y, val_z, val_w);
+        auto v = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
-        auto length = std::sqrt(val_x * val_x + val_y * val_y + val_z * val_z +
-                                val_w * val_w);
-        auto v_length = math::norm(v);
+        auto length = std::sqrt(v.x() * v.x() + v.y() * v.y() + v.z() * v.z() +
+                                v.w() * v.w());
+        auto v_length = ::math::norm(v);
 
         // TODO(wilbert): should check with small generated values as well. Most
         // of the values returned by the generator are quite large (their
         // squares)
 
-        if (math::IsFloat32<T>::value) {
+        if (::math::IsFloat32<T>::value) {
             // Use larger delta, as we're losing precision quickly on f32
-            REQUIRE(FuncClose<T>(v_length, length, static_cast<T>(1e-3)));
+            REQUIRE(::math::func_value_close<T>(v_length, length,
+                                                static_cast<T>(1e-3)));
         } else {
-            REQUIRE(FuncClose<T>(v_length, length, EPSILON));
+            REQUIRE(::math::func_value_close<T>(v_length, length, EPSILON));
         }
     }
 
     SECTION("Vector normalization (in place)") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
-        Vector4 v(val_x, val_y, val_z, val_w);
-        math::normalize_in_place(v);
+        auto v = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        // Compute the norm and normalize the vector manually
+        auto norm = std::sqrt(v.x() * v.x() + v.y() * v.y() + v.z() * v.z() +
+                              v.w() * v.w());
+        auto val_xnorm = v.x() / norm;
+        auto val_ynorm = v.y() / norm;
+        auto val_znorm = v.z() / norm;
+        auto val_wnorm = v.w() / norm;
 
-        auto norm = std::sqrt(val_x * val_x + val_y * val_y + val_z * val_z +
-                              val_w * val_w);
-        auto val_xnorm = val_x / norm;
-        auto val_ynorm = val_y / norm;
-        auto val_znorm = val_z / norm;
-        auto val_wnorm = val_w / norm;
+        // Normalize the vector and make sure it gives the expected result
+        ::math::normalize_in_place(v);
+        REQUIRE(::math::func_all_close<T>(v, val_xnorm, val_ynorm, val_znorm,
+                                          val_wnorm, EPSILON));
 
-        auto v_norm = math::norm(v);
-
-        REQUIRE(FuncClose<T>(v_norm, 1.0, EPSILON));
-        REQUIRE(FuncAllClose<T>(v, val_xnorm, val_ynorm, val_znorm, val_wnorm));
+        // Make sure the norm of the normalized vector is 1.0
+        auto v_norm = ::math::norm(v);
+        REQUIRE(::math::func_value_close<T>(v_norm, 1.0, EPSILON));
     }
 
     SECTION("Vector normalization (out-of place)") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
-        Vector4 v(val_x, val_y, val_z, val_w);
-        auto vn = math::normalize(v);
+        auto v = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        // Compute the norm and normalize the vector manually
+        auto norm = std::sqrt(v.x() * v.x() + v.y() * v.y() + v.z() * v.z() +
+                              v.w() * v.w());
+        auto val_xnorm = v.x() / norm;
+        auto val_ynorm = v.y() / norm;
+        auto val_znorm = v.z() / norm;
+        auto val_wnorm = v.w() / norm;
 
-        auto norm = std::sqrt(val_x * val_x + val_y * val_y + val_z * val_z +
-                              val_w * val_w);
-        auto val_xnorm = val_x / norm;
-        auto val_ynorm = val_y / norm;
-        auto val_znorm = val_z / norm;
-        auto val_wnorm = val_w / norm;
+        // Normalize the vector and make sure it gives the expected result
+        auto vn = ::math::normalize(v);
+        REQUIRE(::math::func_all_close<T>(vn, val_xnorm, val_ynorm, val_znorm,
+                                          val_wnorm, EPSILON));
 
-        auto vn_norm = math::norm(vn);
-
-        REQUIRE(FuncClose<T>(vn_norm, 1.0, EPSILON));
-        REQUIRE(
-            FuncAllClose<T>(vn, val_xnorm, val_ynorm, val_znorm, val_wnorm));
+        // Make sure the norm of the normalized vector is 1.0
+        auto vn_norm = ::math::norm(vn);
+        REQUIRE(::math::func_value_close<T>(vn_norm, 1.0, EPSILON));
     }
 
     SECTION("Vector dot-product") {
-        auto val_x_a = GenRandomValue(T, 2);
-        auto val_y_a = GenRandomValue(T, 2);
-        auto val_z_a = GenRandomValue(T, 2);
-        auto val_w_a = GenRandomValue(T, 2);
+        auto v_a = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+        auto v_b = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
 
-        auto val_x_b = GenRandomValue(T, 2);
-        auto val_y_b = GenRandomValue(T, 2);
-        auto val_z_b = GenRandomValue(T, 2);
-        auto val_w_b = GenRandomValue(T, 2);
+        auto dot = v_a.x() * v_b.x() + v_a.y() * v_b.y() + v_a.z() * v_b.z() +
+                   v_a.w() * v_b.w();
+        auto v_dot = ::math::dot(v_a, v_b);
 
-        Vector4 v_a(val_x_a, val_y_a, val_z_a, val_w_a);
-        Vector4 v_b(val_x_b, val_y_b, val_z_b, val_w_b);
-
-        auto dot = val_x_a * val_x_b + val_y_a * val_y_b + val_z_a * val_z_b +
-                   val_w_a * val_w_b;
-        auto v_dot = math::dot(v_a, v_b);
-
-        if (math::IsFloat32<T>::value) {
+        if (::math::IsFloat32<T>::value) {
             // TODO(wilbert): If scalar version is more precise, then we might
             // have an issue with SIMD instructions not returning the correct
             // value
 
             // Use larger delta, as we're losing precision quickly on f32
-            REQUIRE(FuncClose<T>(v_dot, dot, static_cast<T>(1e-1)));
+            REQUIRE(::math::func_value_close<T>(v_dot, dot, 1e-1));
         } else {
-            REQUIRE(FuncClose<T>(v_dot, dot, EPSILON));
+            REQUIRE(::math::func_value_close<T>(v_dot, dot, EPSILON));
         }
     }
 
     SECTION("Vector additive inverse") {
-        auto val_x = GenRandomValue(T, 10);
-        auto val_y = GenRandomValue(T, 10);
-        auto val_z = GenRandomValue(T, 10);
-        auto val_w = GenRandomValue(T, 10);
-        Vector4 v(val_x, val_y, val_z, val_w);
+        auto v = GENERATE(
+            take(NUM_SAMPLES, ::math::random_vec4<T>(RANGE_MIN, RANGE_MAX)));
+
         auto inv_v = -v;
 
-        REQUIRE(FuncAllClose<T>(inv_v, -val_x, -val_y, -val_z, -val_w));
+        REQUIRE(::math::func_all_close<T>(inv_v, -v.x(), -v.y(), -v.z(), -v.w(),
+                                          EPSILON));
     }
 }
 

--- a/tests/cpp/test_vec4_type.cpp
+++ b/tests/cpp/test_vec4_type.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch.hpp>
 #include <math/vec4_t.hpp>
 
+#include "./common_math_helpers.hpp"
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
@@ -14,92 +16,27 @@
 #pragma warning(disable : 4305)
 #endif
 
-constexpr double RANGE_MIN = -1000.0;
-constexpr double RANGE_MAX = 1000.0;
+constexpr double USER_RANGE_MIN = -1000.0;
+constexpr double USER_RANGE_MAX = 1000.0;
+constexpr double USER_EPSILON = 1e-5;
 
-// NOLINTNEXTLINE
-#define GenRandomValue(Type, Nsamples)                           \
-    GENERATE(take(Nsamples, random(static_cast<Type>(RANGE_MIN), \
-                                   static_cast<Type>(RANGE_MAX))))
-
-template <typename T>
-constexpr auto FuncClose(T a, T b, T eps) -> bool {
-    return ((a - b) < eps) && ((a - b) > -eps);
-}
-
-template <typename T>
-auto FuncAllClose(const math::Vector4<T>& vec, T x, T y, T z, T w) -> bool {
-    constexpr T EPSILON = static_cast<T>(math::EPS);
-    return FuncClose<T>(vec.x(), x, EPSILON) &&
-           FuncClose<T>(vec.y(), y, EPSILON) &&
-           FuncClose<T>(vec.z(), z, EPSILON) &&
-           FuncClose<T>(vec.w(), w, EPSILON);
-}
+constexpr auto NUM_SAMPLES = 10;
 
 // NOLINTNEXTLINE
 TEMPLATE_TEST_CASE("Vector4 class (vec4_t) constructors", "[vec4_t][template]",
-                   math::float32_t, math::float64_t) {
+                   ::math::float32_t, ::math::float64_t) {
     using T = TestType;
-    using Vector4 = math::Vector4<T>;
+    using Vector4 = ::math::Vector4<T>;
 
-    // Checking the correctness of the constructors
+    constexpr T RANGE_MIN = static_cast<T>(USER_RANGE_MIN);
+    constexpr T RANGE_MAX = static_cast<T>(USER_RANGE_MAX);
+    constexpr T EPSILON = static_cast<T>(USER_EPSILON);
 
-    SECTION("Default constructor") {
-        Vector4 v;
-        REQUIRE(FuncAllClose<T>(v, 0.0, 0.0, 0.0, 0.0));
-    }
-
-    SECTION("From single scalar argument") {
-        auto val_x = GenRandomValue(T, 100);
-
-        Vector4 v(val_x);
-
-        REQUIRE(FuncAllClose<T>(v, val_x, val_x, val_x, val_x));
-    }
-
-    SECTION("From two scalar arguments") {
-        auto val_x = GenRandomValue(T, 10);
-        auto val_y = GenRandomValue(T, 10);
-
-        Vector4 v(val_x, val_y);
-
-        REQUIRE(FuncAllClose<T>(v, val_x, val_y, val_y, val_y));
-    }
-
-    SECTION("From three scalar arguments") {
-        auto val_x = GenRandomValue(T, 10);
-        auto val_y = GenRandomValue(T, 10);
-        auto val_z = GenRandomValue(T, 10);
-
-        Vector4 v(val_x, val_y, val_z);
-
-        REQUIRE(FuncAllClose<T>(v, val_x, val_y, val_z, val_z));
-    }
-
-    SECTION(
-        "From four scalar arguments, from initializer_list, or using "
-        "comma-initializer") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
-
-        Vector4 v_1(val_x, val_y, val_z, val_w);
-        Vector4 v_2 = {val_x, val_y, val_z, val_w};
-        Vector4 v_3;
-        // cppcheck-suppress constStatement
-        v_3 << val_x, val_y, val_z, val_w;
-
-        REQUIRE(FuncAllClose<T>(v_1, val_x, val_y, val_z, val_w));
-        REQUIRE(FuncAllClose<T>(v_2, val_x, val_y, val_z, val_w));
-        REQUIRE(FuncAllClose<T>(v_3, val_x, val_y, val_z, val_w));
-    }
-
-    SECTION("Accessors .x(), .y(), .z(), .w()") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
+    SECTION("Get/Set using .x(), .y()") {
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_z = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_w = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Vector4 v;
         v.x() = val_x;
@@ -107,21 +44,82 @@ TEMPLATE_TEST_CASE("Vector4 class (vec4_t) constructors", "[vec4_t][template]",
         v.z() = val_z;
         v.w() = val_w;
 
-        REQUIRE(FuncAllClose<T>(v, val_x, val_y, val_z, val_w));
+        REQUIRE(::math::func_value_close<T>(v.x(), val_x, EPSILON));
+        REQUIRE(::math::func_value_close<T>(v.y(), val_y, EPSILON));
+        REQUIRE(::math::func_value_close<T>(v.z(), val_z, EPSILON));
+        REQUIRE(::math::func_value_close<T>(v.w(), val_w, EPSILON));
+    }
+
+    SECTION("Default constructor") {
+        Vector4 v;
+        REQUIRE(::math::func_all_close<T>(v, 0.0, 0.0, 0.0, 0.0, EPSILON));
+    }
+
+    SECTION("From single scalar argument") {
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+
+        Vector4 v(val_x);
+        // The given argument is copied to all other entries as well
+        REQUIRE(
+            ::math::func_all_close<T>(v, val_x, val_x, val_x, val_x, EPSILON));
+    }
+
+    SECTION("From two scalar arguments") {
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+
+        Vector4 v(val_x, val_y);
+        // The y component gets copied for the z and w components
+        REQUIRE(
+            ::math::func_all_close<T>(v, val_x, val_y, val_y, val_y, EPSILON));
+    }
+
+    SECTION("From three scalar arguments") {
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_z = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+
+        Vector4 v(val_x, val_y, val_z);
+
+        REQUIRE(
+            ::math::func_all_close<T>(v, val_x, val_y, val_z, val_z, EPSILON));
+    }
+
+    SECTION(
+        "From four scalar arguments, from initializer_list, or using "
+        "comma-initializer") {
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_z = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_w = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+
+        Vector4 v_1(val_x, val_y, val_z, val_w);
+        Vector4 v_2 = {val_x, val_y, val_z, val_w};
+        Vector4 v_3;
+        // cppcheck-suppress constStatement
+        v_3 << val_x, val_y, val_z, val_w;
+
+        REQUIRE(::math::func_all_close<T>(v_1, val_x, val_y, val_z, val_w,
+                                          EPSILON));
+        REQUIRE(::math::func_all_close<T>(v_2, val_x, val_y, val_z, val_w,
+                                          EPSILON));
+        REQUIRE(::math::func_all_close<T>(v_3, val_x, val_y, val_z, val_w,
+                                          EPSILON));
     }
 
     SECTION("Accessors [index]") {
-        auto val_x = GenRandomValue(T, 4);
-        auto val_y = GenRandomValue(T, 4);
-        auto val_z = GenRandomValue(T, 4);
-        auto val_w = GenRandomValue(T, 4);
+        auto val_x = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_y = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_z = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
+        auto val_w = gen_random_value(T, RANGE_MIN, RANGE_MAX, NUM_SAMPLES);
 
         Vector4 v;
         v[0] = val_x;
         v[1] = val_y;
         v[2] = val_z;
         v[3] = val_w;
-        REQUIRE(FuncAllClose<T>(v, val_x, val_y, val_z, val_w));
+        REQUIRE(
+            ::math::func_all_close<T>(v, val_x, val_y, val_z, val_w, EPSILON));
     }
 }
 


### PR DESCRIPTION
* Fixes custom Catch2 generators (issue with virtual inheritance)
* Updates `unittests` to use fixed custom generators instead of manually creating random numbers.