### PR TITLE
Adds support for returning views from vector and matrix types

### DIFF
--- a/docs/References.md
+++ b/docs/References.md
@@ -8,6 +8,7 @@
   conversions from this ROS package [here][3] (implements in Python the
   functions described in the previous [book][2])
 * This [video][4] is also a good refresher on Euler angles.
+* This [issue][7] explains how to expose views.
 
 ---
 
@@ -18,3 +19,4 @@
 [4]: <https://youtu.be/3Zjf95Jw2UE> (video-euler-angles-1)
 [5]: <https://github.com/davheld/tf/blob/master/src/tf/transformations.py#L1100> (reference-impl-ros-tf-quat-from-euler)
 [6]: <https://github.com/davheld/tf/blob/master/src/tf/transformations.py#L1031> (reference-impl-ros-tf-euler-from-matrix)
+[7]: <https://github.com/pybind/pybind11/issues/2271> (pybind11-array-view)

--- a/python/math3d/bindings/mat2_py.hpp
+++ b/python/math3d/bindings/mat2_py.hpp
@@ -45,14 +45,15 @@ auto bindings_matrix2(py::module& m, const char* class_name) -> void {
         // clang-format on
         .def("numpy",
              [](const Class& self) -> py::array_t<T> {
-                 return ::math::mat2_to_nparray<T>(self);
+                 return py::array_t<T>(
+                     {Class::MATRIX_SIZE, Class::MATRIX_SIZE},
+                     {sizeof(T), sizeof(T) * Class::MATRIX_SIZE}, self.data(),
+                     py::cast(self));
              })
         .def("flatten",
              [](const Class& self) -> py::array_t<T> {
-                 auto array_np = py::array_t<T>(Class::BUFFER_SIZE);
-                 memcpy(array_np.request().ptr, self.data(),
-                        Class::BUFFER_SIZE * sizeof(T));
-                 return array_np;
+                 return py::array_t<T>(Class::BUFFER_SIZE, self.data(),
+                                       py::cast(self));
              })
         .def_property_readonly(
             "T",

--- a/python/math3d/bindings/mat3_py.hpp
+++ b/python/math3d/bindings/mat3_py.hpp
@@ -45,14 +45,15 @@ auto bindings_matrix3(py::module& m, const char* class_name) -> void {
         // clang-format on
         .def("numpy",
              [](const Class& self) -> py::array_t<T> {
-                 return ::math::mat3_to_nparray<T>(self);
+                 return py::array_t<T>(
+                     {Class::MATRIX_SIZE, Class::MATRIX_SIZE},
+                     {sizeof(T), sizeof(T) * Class::MATRIX_SIZE}, self.data(),
+                     py::cast(self));
              })
         .def("flatten",
              [](const Class& self) -> py::array_t<T> {
-                 auto array_np = py::array_t<T>(Class::BUFFER_SIZE);
-                 memcpy(array_np.request().ptr, self.data(),
-                        Class::BUFFER_SIZE * sizeof(T));
-                 return array_np;
+                 return py::array_t<T>(Class::BUFFER_SIZE, self.data(),
+                                       py::cast(self));
              })
         .def_property_readonly(
             "T",

--- a/python/math3d/bindings/mat4_py.hpp
+++ b/python/math3d/bindings/mat4_py.hpp
@@ -48,14 +48,15 @@ auto bindings_matrix4(py::module& m, const char* class_name) -> void {
         // clang-format on
         .def("numpy",
              [](const Class& self) -> py::array_t<T> {
-                 return ::math::mat4_to_nparray<T>(self);
+                 return py::array_t<T>(
+                     {Class::MATRIX_SIZE, Class::MATRIX_SIZE},
+                     {sizeof(T), sizeof(T) * Class::MATRIX_SIZE}, self.data(),
+                     py::cast(self));
              })
         .def("flatten",
              [](const Class& self) -> py::array_t<T> {
-                 auto array_np = py::array_t<T>(Class::BUFFER_SIZE);
-                 memcpy(array_np.request().ptr, self.data(),
-                        Class::BUFFER_SIZE * sizeof(T));
-                 return array_np;
+                 return py::array_t<T>(Class::BUFFER_SIZE, self.data(),
+                                       py::cast(self));
              })
         .def_property_readonly(
             "T",

--- a/python/math3d/bindings/vec2_py.hpp
+++ b/python/math3d/bindings/vec2_py.hpp
@@ -49,33 +49,31 @@ auto bindings_vector2(py::module& m, const char* class_name) -> void {
             VECTOR_PROPERTY(y)
             VECTOR_OPERATORS(T)
             VECTOR_GETSET_ITEM(2, T)
-            .def("dot", [](const Class& self, const Class& other) -> T {
-                return self.dot(other);
-            })
-            .def("norm", [](const Class& self) -> T {
-                return self.length();
-            })
-            .def("squareNorm", [](const Class& self) -> T {
-                return self.lengthSquare();
-            })
-            .def("normalize", [](const Class& self) -> Class {
-                return self.normalized();
-            })
-            .def("normalize_", [](Class& self) -> void {
-                self.normalize();
-            })
-            // clant-format on
-            .def("numpy", [](const Class& self) -> py::array_t<T> {
-                return ::math::vec2_to_nparray<T>(self);
-            })
+            // clang-format on
+            .def("dot",
+                 [](const Class& self, const Class& other) -> T {
+                     return self.dot(other);
+                 })
+            .def("norm", [](const Class& self) -> T { return self.length(); })
+            .def("squareNorm",
+                 [](const Class& self) -> T { return self.lengthSquare(); })
+            .def("normalize",
+                 [](const Class& self) -> Class { return self.normalized(); })
+            .def("normalize_", [](Class& self) -> void { self.normalize(); })
+            .def("numpy",
+                 [](const Class& self) -> py::array_t<T> {
+                     return py::array_t<T>(Class::VECTOR_SIZE, self.data(),
+                                           py::cast(self));
+                 })
             // NOLINTNEXTLINE
-            .def_property_readonly("ndim", [](const Class&) {
-                return Class::VECTOR_NDIM;
-            })
+            .def_property_readonly(
+                "ndim", [](const Class&) { return Class::VECTOR_NDIM; })
             // NOLINTNEXTLINE
-            .def_property_readonly("shape", [](const Class&) {
-                return std::pair<uint32_t, uint32_t>(1, 2);
-            })
+            .def_property_readonly("shape",
+                                   [](const Class&) {
+                                       return std::pair<uint32_t, uint32_t>(1,
+                                                                            2);
+                                   })
             .def("__repr__", [](const Class& self) -> py::str {
                 return py::str("Vector2{}(x={}, y={})")
                     .format((IsFloat32<T>::value ? "f" : "d"), self.x(),

--- a/python/math3d/bindings/vec3_py.hpp
+++ b/python/math3d/bindings/vec3_py.hpp
@@ -49,36 +49,35 @@ auto bindings_vector3(py::module& m, const char* class_name) -> void {
             VECTOR_PROPERTY(z)
             VECTOR_OPERATORS(T)
             VECTOR_GETSET_ITEM(3, T)
-            // clant-format on
-            .def("dot", [](const Class& self, const Class& other) -> T {
-                return self.dot(other);
-            })
-            .def("norm", [](const Class& self) -> T {
-                return self.length();
-            })
-            .def("squareNorm", [](const Class& self) -> T {
-                return self.lengthSquare();
-            })
-            .def("normalize", [](const Class& self) -> Class {
-                return self.normalized();
-            })
-            .def("normalize_", [](Class& self) -> void {
-                self.normalize();
-            })
-            .def("cross", [](const Class& self, const Class& other) -> Class {
-                return self.cross(other);
-            })
-            .def("numpy", [](const Class& self) -> py::array_t<T> {
-                return ::math::vec3_to_nparray<T>(self);
-            })
+            // clang-format on
+            .def("dot",
+                 [](const Class& self, const Class& other) -> T {
+                     return self.dot(other);
+                 })
+            .def("norm", [](const Class& self) -> T { return self.length(); })
+            .def("squareNorm",
+                 [](const Class& self) -> T { return self.lengthSquare(); })
+            .def("normalize",
+                 [](const Class& self) -> Class { return self.normalized(); })
+            .def("normalize_", [](Class& self) -> void { self.normalize(); })
+            .def("cross",
+                 [](const Class& self, const Class& other) -> Class {
+                     return self.cross(other);
+                 })
+            .def("numpy",
+                 [](const Class& self) -> py::array_t<T> {
+                     return py::array_t<T>(Class::VECTOR_SIZE, self.data(),
+                                           py::cast(self));
+                 })
             // NOLINTNEXTLINE
-            .def_property_readonly("ndim", [](const Class&) {
-                return Class::VECTOR_NDIM;
-            })
+            .def_property_readonly(
+                "ndim", [](const Class&) { return Class::VECTOR_NDIM; })
             // NOLINTNEXTLINE
-            .def_property_readonly("shape", [](const Class&) {
-                return std::pair<uint32_t, uint32_t>(1, 3);
-            })
+            .def_property_readonly("shape",
+                                   [](const Class&) {
+                                       return std::pair<uint32_t, uint32_t>(1,
+                                                                            3);
+                                   })
             .def("__repr__", [](const Class& self) -> py::str {
                 return py::str("Vector3{}(x={}, y={}, z={})")
                     .format((IsFloat32<T>::value ? "f" : "d"), self.x(),

--- a/python/math3d/bindings/vec4_py.hpp
+++ b/python/math3d/bindings/vec4_py.hpp
@@ -51,33 +51,31 @@ auto bindings_vector4(py::module& m, const char* class_name) -> void {
             VECTOR_PROPERTY(w)
             VECTOR_OPERATORS(T)
             VECTOR_GETSET_ITEM(4, T)
-            // clant-format on
-            .def("dot", [](const Class& self, const Class& other) -> T {
-                return self.dot(other);
-            })
-            .def("norm", [](const Class& self) -> T {
-                return self.length();
-            })
-            .def("squareNorm", [](const Class& self) -> T {
-                return self.lengthSquare();
-            })
-            .def("normalize", [](const Class& self) -> Class {
-                return self.normalized();
-            })
-            .def("normalize_", [](Class& self) -> void {
-                self.normalize();
-            })
-            .def("numpy", [](const Class& self) -> py::array_t<T> {
-                return ::math::vec4_to_nparray<T>(self);
-            })
+            // clang-format on
+            .def("dot",
+                 [](const Class& self, const Class& other) -> T {
+                     return self.dot(other);
+                 })
+            .def("norm", [](const Class& self) -> T { return self.length(); })
+            .def("squareNorm",
+                 [](const Class& self) -> T { return self.lengthSquare(); })
+            .def("normalize",
+                 [](const Class& self) -> Class { return self.normalized(); })
+            .def("normalize_", [](Class& self) -> void { self.normalize(); })
+            .def("numpy",
+                 [](const Class& self) -> py::array_t<T> {
+                     return py::array_t<T>(Class::VECTOR_SIZE, self.data(),
+                                           py::cast(self));
+                 })
             // NOLINTNEXTLINE
-            .def_property_readonly("ndim", [](const Class&) {
-                return Class::VECTOR_NDIM;
-            })
+            .def_property_readonly(
+                "ndim", [](const Class&) { return Class::VECTOR_NDIM; })
             // NOLINTNEXTLINE
-            .def_property_readonly("shape", [](const Class&) {
-                return std::pair<uint32_t, uint32_t>(1, 4);
-            })
+            .def_property_readonly("shape",
+                                   [](const Class&) {
+                                       return std::pair<uint32_t, uint32_t>(1,
+                                                                            4);
+                                   })
             .def("__repr__", [](const Class& self) -> py::str {
                 return py::str("Vector4{}(x={}, y={}, z={}, w={})")
                     .format((IsFloat32<T>::value ? "f" : "d"), self.x(),


### PR DESCRIPTION
# Description
This PR adds support for `vecX_t` and `matX_t` to expose a view instead of an array with the internal memory copied. You can use the following methods:

```python
import numpy as np
import math3d as m3d

m = m3d.Matrix4d.RotationX(np.pi / 4.)
m_np = m.numpy()
# m_np is an array-view of the given 4x4 matrix
rotmat = m_np[0:3, 0:3]
```