### PR TITLE
Remove usage of SFINAE pattern in API declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(
   math3d
   VERSION 0.6.15
   DESCRIPTION "A basic math library for spatial algebra"
-  HOMEPAGE_URL "https://github.com/wpumacay/math"
+  HOMEPAGE_URL "https://github.com/wpumacay/math3d"
   LANGUAGES C CXX)
 
 # -------------------------------------

--- a/include/math/euler_t.hpp
+++ b/include/math/euler_t.hpp
@@ -166,9 +166,6 @@ auto Euler<T>::setFromAxisAngle(const Vec3& axis, T angle) -> void {
 // ***************************************************************************//
 
 template <typename T>
-using SFINAE_EULER_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
-
-template <typename T, SFINAE_EULER_GUARD<T> = nullptr>
 auto operator<<(std::ostream& output_stream, const Euler<T>& src)
     -> std::ostream& {
     output_stream << src.toString();

--- a/include/math/impl/mat2_t_scalar_impl.hpp
+++ b/include/math/impl/mat2_t_scalar_impl.hpp
@@ -17,10 +17,6 @@ template <typename T>
 using Vec2Buffer = typename Vector2<T>::BufferType;
 
 template <typename T>
-using SFINAE_MAT2_SCALAR_GUARD =
-    typename std::enable_if<IsScalar<T>::value>::type*;
-
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
 MATH3D_INLINE auto kernel_transpose_inplace_mat2(Mat2Buffer<T>& cols) -> void {
     for (uint32_t col = 1; col < Matrix2<T>::MATRIX_SIZE; ++col) {
         for (uint32_t row = 0; row < Matrix2<T>::MATRIX_SIZE; ++row) {
@@ -29,12 +25,12 @@ MATH3D_INLINE auto kernel_transpose_inplace_mat2(Mat2Buffer<T>& cols) -> void {
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_trace_mat2(const Mat2Buffer<T>& mat) -> T {
     return mat[0][0] + mat[1][1];
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_determinant_mat2(const Mat2Buffer<T>& mat) -> T {
     auto m00 = mat[0][0];
     auto m10 = mat[0][1];
@@ -44,7 +40,7 @@ MATH3D_INLINE auto kernel_determinant_mat2(const Mat2Buffer<T>& mat) -> T {
     return m00 * m11 - m10 * m01;
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_inverse_mat2(Mat2Buffer<T>& dst,
                                        const Mat2Buffer<T>& src) -> void {
     auto m00 = src[0][0];
@@ -60,7 +56,7 @@ MATH3D_INLINE auto kernel_inverse_mat2(Mat2Buffer<T>& dst,
     dst[1][1] = m00 / det;
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_add_mat2(Mat2Buffer<T>& dst, const Mat2Buffer<T>& lhs,
                                    const Mat2Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix2<T>::MATRIX_SIZE; ++col) {
@@ -70,7 +66,7 @@ MATH3D_INLINE auto kernel_add_mat2(Mat2Buffer<T>& dst, const Mat2Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_sub_mat2(Mat2Buffer<T>& dst, const Mat2Buffer<T>& lhs,
                                    const Mat2Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix2<T>::MATRIX_SIZE; ++col) {
@@ -80,7 +76,7 @@ MATH3D_INLINE auto kernel_sub_mat2(Mat2Buffer<T>& dst, const Mat2Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_scale_mat2(Mat2Buffer<T>& dst, T scale,
                                      const Mat2Buffer<T>& mat) -> void {
     for (uint32_t col = 0; col < Matrix2<T>::MATRIX_SIZE; ++col) {
@@ -90,7 +86,7 @@ MATH3D_INLINE auto kernel_scale_mat2(Mat2Buffer<T>& dst, T scale,
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_mat2(Mat2Buffer<T>& dst,
                                       const Mat2Buffer<T>& lhs,
                                       const Mat2Buffer<T>& rhs) -> void {
@@ -104,7 +100,7 @@ MATH3D_INLINE auto kernel_matmul_mat2(Mat2Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_vec_mat2(Vec2Buffer<T>& dst,
                                           const Mat2Buffer<T>& mat,
                                           const Vec2Buffer<T>& vec) -> void {
@@ -112,7 +108,7 @@ MATH3D_INLINE auto kernel_matmul_vec_mat2(Vec2Buffer<T>& dst,
     dst[1] = mat[0][1] * vec[0] + mat[1][1] * vec[1];
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_hadamard_mat2(Mat2Buffer<T>& dst,
                                         const Mat2Buffer<T>& lhs,
                                         const Mat2Buffer<T>& rhs) -> void {
@@ -123,7 +119,7 @@ MATH3D_INLINE auto kernel_hadamard_mat2(Mat2Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT2_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_compare_eq_mat2(const Mat2Buffer<T>& lhs,
                                           const Mat2Buffer<T>& rhs) -> bool {
     for (uint32_t col = 0; col < Matrix2<T>::MATRIX_SIZE; ++col) {

--- a/include/math/impl/mat3_t_scalar_impl.hpp
+++ b/include/math/impl/mat3_t_scalar_impl.hpp
@@ -15,22 +15,18 @@ template <typename T>
 using Vec3Buffer = typename Vector3<T>::BufferType;
 
 template <typename T>
-using SFINAE_MAT3_SCALAR_GUARD =
-    typename std::enable_if<IsScalar<T>::value>::type*;
-
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
 MATH3D_INLINE auto kernel_transpose_inplace_mat3(Mat3Buffer<T>& mat) -> void {
     std::swap(mat[0][1], mat[1][0]);
     std::swap(mat[0][2], mat[2][0]);
     std::swap(mat[1][2], mat[2][1]);
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_trace_mat3(const Mat3Buffer<T>& mat) -> T {
     return mat[0][0] + mat[1][1] + mat[2][2];
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_determinant_mat3(const Mat3Buffer<T>& mat) -> T {
     auto m00 = mat[0][0];
     auto m10 = mat[0][1];
@@ -52,7 +48,7 @@ MATH3D_INLINE auto kernel_determinant_mat3(const Mat3Buffer<T>& mat) -> T {
     return m00 * c00 + m10 * c10 + m20 * c20;
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_inverse_mat3(Mat3Buffer<T>& dst,
                                        const Mat3Buffer<T>& src) -> void {
     auto m00 = src[0][0];
@@ -97,7 +93,7 @@ MATH3D_INLINE auto kernel_inverse_mat3(Mat3Buffer<T>& dst,
     dst[2][2] = c22 * inv_det;
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_add_mat3(Mat3Buffer<T>& dst, const Mat3Buffer<T>& lhs,
                                    const Mat3Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix3<T>::MATRIX_SIZE; ++col) {
@@ -107,7 +103,7 @@ MATH3D_INLINE auto kernel_add_mat3(Mat3Buffer<T>& dst, const Mat3Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_sub_mat3(Mat3Buffer<T>& dst, const Mat3Buffer<T>& lhs,
                                    const Mat3Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix3<T>::MATRIX_SIZE; ++col) {
@@ -117,7 +113,7 @@ MATH3D_INLINE auto kernel_sub_mat3(Mat3Buffer<T>& dst, const Mat3Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_scale_mat3(Mat3Buffer<T>& dst, T scale,
                                      const Mat3Buffer<T>& mat) -> void {
     for (uint32_t col = 0; col < Matrix3<T>::MATRIX_SIZE; ++col) {
@@ -127,7 +123,7 @@ MATH3D_INLINE auto kernel_scale_mat3(Mat3Buffer<T>& dst, T scale,
     }
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_mat3(Mat3Buffer<T>& dst,
                                       const Mat3Buffer<T>& lhs,
                                       const Mat3Buffer<T>& rhs) -> void {
@@ -141,7 +137,7 @@ MATH3D_INLINE auto kernel_matmul_mat3(Mat3Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_vec_mat3(Vec3Buffer<T>& dst,
                                           const Mat3Buffer<T>& mat,
                                           const Vec3Buffer<T>& vec) -> void {
@@ -150,7 +146,7 @@ MATH3D_INLINE auto kernel_matmul_vec_mat3(Vec3Buffer<T>& dst,
     dst[2] = mat[0][2] * vec[0] + mat[1][2] * vec[1] + mat[2][2] * vec[2];
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_hadamard_mat3(Mat3Buffer<T>& dst,
                                         const Mat3Buffer<T>& lhs,
                                         const Mat3Buffer<T>& rhs) -> void {
@@ -161,7 +157,7 @@ MATH3D_INLINE auto kernel_hadamard_mat3(Mat3Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT3_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_compare_eq_mat3(const Mat3Buffer<T>& lhs,
                                           const Mat3Buffer<T>& rhs) -> bool {
     for (uint32_t col = 0; col < Matrix3<T>::MATRIX_SIZE; ++col) {

--- a/include/math/impl/mat4_t_scalar_impl.hpp
+++ b/include/math/impl/mat4_t_scalar_impl.hpp
@@ -15,10 +15,6 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-using SFINAE_MAT4_SCALAR_GUARD =
-    typename std::enable_if<IsScalar<T>::value>::type*;
-
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 MATH3D_INLINE auto kernel_transpose_inplace_mat4(Mat4Buffer<T>& mat) -> void {
     std::swap(mat[0][1], mat[1][0]);
     std::swap(mat[0][2], mat[2][0]);
@@ -28,12 +24,12 @@ MATH3D_INLINE auto kernel_transpose_inplace_mat4(Mat4Buffer<T>& mat) -> void {
     std::swap(mat[2][3], mat[3][2]);
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_trace_mat4(const Mat4Buffer<T>& mat) -> T {
     return mat[0][0] + mat[1][1] + mat[2][2] + mat[3][3];
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_determinant_mat4(const Mat4Buffer<T>& mat) -> T {
     auto m00 = mat[0][0];
     auto m10 = mat[0][1];
@@ -69,7 +65,7 @@ MATH3D_INLINE auto kernel_determinant_mat4(const Mat4Buffer<T>& mat) -> T {
            m30 * (m01 * m1223 - m11 * m0223 + m21 * m0123);
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_inverse_mat4(Mat4Buffer<T>& dst,
                                        const Mat4Buffer<T>& src) -> void {
     auto m00 = src[0][0];
@@ -136,7 +132,7 @@ MATH3D_INLINE auto kernel_inverse_mat4(Mat4Buffer<T>& dst,
     dst[3][3] = (m22 * m0101 - m12 * m0201 + m02 * m1201) * inv_det;
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_add_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                    const Mat4Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix4<T>::MATRIX_SIZE; ++col) {
@@ -146,7 +142,7 @@ MATH3D_INLINE auto kernel_add_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_sub_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                    const Mat4Buffer<T>& rhs) -> void {
     for (uint32_t col = 0; col < Matrix4<T>::MATRIX_SIZE; ++col) {
@@ -156,7 +152,7 @@ MATH3D_INLINE auto kernel_sub_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_scale_mat4(Mat4Buffer<T>& dst, T scale,
                                      const Mat4Buffer<T>& mat) -> void {
     for (uint32_t col = 0; col < Matrix4<T>::MATRIX_SIZE; ++col) {
@@ -166,7 +162,7 @@ MATH3D_INLINE auto kernel_scale_mat4(Mat4Buffer<T>& dst, T scale,
     }
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_mat4(Mat4Buffer<T>& dst,
                                       const Mat4Buffer<T>& lhs,
                                       const Mat4Buffer<T>& rhs) -> void {
@@ -180,7 +176,7 @@ MATH3D_INLINE auto kernel_matmul_mat4(Mat4Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_matmul_vec_mat4(Vec4Buffer<T>& dst,
                                           const Mat4Buffer<T>& mat,
                                           const Vec4Buffer<T>& vec) -> void {
@@ -194,7 +190,7 @@ MATH3D_INLINE auto kernel_matmul_vec_mat4(Vec4Buffer<T>& dst,
              mat[3][3] * vec[3];
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_hadamard_mat4(Mat4Buffer<T>& dst,
                                         const Mat4Buffer<T>& lhs,
                                         const Mat4Buffer<T>& rhs) -> void {
@@ -205,7 +201,7 @@ MATH3D_INLINE auto kernel_hadamard_mat4(Mat4Buffer<T>& dst,
     }
 }
 
-template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_compare_eq_mat4(const Mat4Buffer<T>& lhs,
                                           const Mat4Buffer<T>& rhs) -> bool {
     for (uint32_t col = 0; col < Matrix4<T>::MATRIX_SIZE; ++col) {

--- a/include/math/impl/quat_t_scalar_impl.hpp
+++ b/include/math/impl/quat_t_scalar_impl.hpp
@@ -11,10 +11,6 @@ template <typename T>
 using QuatBuffer = typename Quaternion<T>::BufferType;
 
 template <typename T>
-using SFINAE_QUAT_SCALAR_GUARD =
-    typename std::enable_if<IsScalar<T>::value>::type*;
-
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
 MATH3D_INLINE auto kernel_add_quat(QuatBuffer<T>& dst, const QuatBuffer<T>& lhs,
                                    const QuatBuffer<T>& rhs) -> void {
     for (uint32_t i = 0; i < Quaternion<T>::QUAT_SIZE; ++i) {
@@ -22,7 +18,7 @@ MATH3D_INLINE auto kernel_add_quat(QuatBuffer<T>& dst, const QuatBuffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_sub_quat(QuatBuffer<T>& dst, const QuatBuffer<T>& lhs,
                                    const QuatBuffer<T>& rhs) -> void {
     for (uint32_t i = 0; i < Quaternion<T>::QUAT_SIZE; ++i) {
@@ -30,7 +26,7 @@ MATH3D_INLINE auto kernel_sub_quat(QuatBuffer<T>& dst, const QuatBuffer<T>& lhs,
     }
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_scale_quat(QuatBuffer<T>& dst, T scale,
                                      const QuatBuffer<T>& quat) -> void {
     for (uint32_t i = 0; i < Quaternion<T>::QUAT_SIZE; ++i) {
@@ -38,7 +34,7 @@ MATH3D_INLINE auto kernel_scale_quat(QuatBuffer<T>& dst, T scale,
     }
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_quatmul_quat(QuatBuffer<T>& dst,
                                        const QuatBuffer<T>& lhs,
                                        const QuatBuffer<T>& rhs) -> void {
@@ -58,13 +54,13 @@ MATH3D_INLINE auto kernel_quatmul_quat(QuatBuffer<T>& dst,
     dst[3] = a_w * b_z + b_w * a_z + a_x * b_y - b_x * a_y;
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_length_square_quat(const QuatBuffer<T>& quat) -> T {
     return quat[0] * quat[0] + quat[1] * quat[1] + quat[2] * quat[2] +
            quat[3] * quat[3];
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_normalize_in_place_quat(QuatBuffer<T>& quat) -> void {
     auto length = std::sqrt(kernel_length_square_quat<T>(quat));
     for (uint32_t i = 0; i < Quaternion<T>::QUAT_SIZE; ++i) {
@@ -72,7 +68,7 @@ MATH3D_INLINE auto kernel_normalize_in_place_quat(QuatBuffer<T>& quat) -> void {
     }
 }
 
-template <typename T, SFINAE_QUAT_SCALAR_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto kernel_compare_eq_quat(const QuatBuffer<T>& lhs,
                                           const QuatBuffer<T>& rhs) -> bool {
     constexpr T EPSILON = static_cast<T>(math::EPS);

--- a/include/math/mat2_t.hpp
+++ b/include/math/mat2_t.hpp
@@ -39,8 +39,8 @@ template <typename T>
 auto Matrix2<T>::Scale(const Vector2<T>& scale) -> Matrix2<T> {
     // clang-format off
     return Matrix2<T>(
-        scale.x(), 0.0,
-        0.0, scale.y());
+        scale.x()  ,    0.0,
+            0.0    ,  scale.y());
     // clang-format on
 }
 
@@ -62,11 +62,8 @@ auto Matrix2<T>::Zeros() -> Matrix2<T> {
 //                       Matrix Methods implementation                        //
 // ***************************************************************************//
 
-template <typename T>
-using SFINAE_MAT2_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
-
 /// Returns the tranpose of the given matrix
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto transpose(const Matrix2<T>& mat) -> Matrix2<T> {
     Matrix2<T> dst = mat;
     scalar::kernel_transpose_inplace_mat2<T>(dst.elements());
@@ -74,25 +71,25 @@ MATH3D_INLINE auto transpose(const Matrix2<T>& mat) -> Matrix2<T> {
 }
 
 /// Transposes the given matrix in place
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto transposeInPlace(Matrix2<T>& mat) -> void {  // NOLINT
     scalar::kernel_transpose_inplace_mat2<T>(mat.elements());
 }
 
 /// Returns the trace (sum of diagonal elements) of the matrix
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto trace(const Matrix2<T>& mat) -> T {
     return scalar::kernel_trace_mat2<T>(mat.elements());
 }
 
 /// Returns the determinant of the matrix
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto determinant(const Matrix2<T>& mat) -> T {
     return scalar::kernel_determinant_mat2<T>(mat.elements());
 }
 
 /// Returns the inverse of the matrix
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto inverse(const Matrix2<T>& mat) -> Matrix2<T> {
     Matrix2<T> dst;
     scalar::kernel_inverse_mat2<T>(dst.elements(), mat.elements());
@@ -104,7 +101,7 @@ MATH3D_INLINE auto inverse(const Matrix2<T>& mat) -> Matrix2<T> {
 // ***************************************************************************//
 
 /// Returns the matrix sum of the two given matrices
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator+(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -118,7 +115,7 @@ MATH3D_INLINE auto operator+(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator-(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -132,7 +129,7 @@ MATH3D_INLINE auto operator-(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(double scale, const Matrix2<T>& mat)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -149,7 +146,7 @@ MATH3D_INLINE auto operator*(double scale, const Matrix2<T>& mat)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix2<T>& mat, double scale)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -166,7 +163,7 @@ MATH3D_INLINE auto operator*(const Matrix2<T>& mat, double scale)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -181,7 +178,7 @@ MATH3D_INLINE auto operator*(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix2<T>& lhs_mat,
                              const Vector2<T>& rhs_vec) -> Vector2<T> {
     Vector2<T> dst;
@@ -198,7 +195,7 @@ MATH3D_INLINE auto operator*(const Matrix2<T>& lhs_mat,
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto hadamard(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> Matrix2<T> {
     Matrix2<T> dst;
@@ -215,19 +212,19 @@ MATH3D_INLINE auto hadamard(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator==(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> bool {
     return scalar::kernel_compare_eq_mat2<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator!=(const Matrix2<T>& lhs, const Matrix2<T>& rhs)
     -> bool {
     return !scalar::kernel_compare_eq_mat2<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 auto operator<<(std::ostream& output_stream, const Matrix2<T>& src)
     -> std::ostream& {
     constexpr int PRECISION_DIGITS = 10;
@@ -237,7 +234,7 @@ auto operator<<(std::ostream& output_stream, const Matrix2<T>& src)
     return output_stream;
 }
 
-template <typename T, SFINAE_MAT2_GUARD<T> = nullptr>
+template <typename T>
 auto operator>>(std::istream& input_stream, Matrix2<T>& dst) -> std::istream& {
     // Based on ignition-math implementation https://bit.ly/3MPgPcW
     input_stream.setf(std::ios_base::skipws);

--- a/include/math/mat3_t.hpp
+++ b/include/math/mat3_t.hpp
@@ -149,43 +149,40 @@ auto Matrix3<T>::Zeros() -> Matrix3<T> {
 //                     Matrix Operations and Functions                        //
 // ***************************************************************************//
 
-template <typename T>
-using SFINAE_MAT3_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
-
 /// Returns the tranpose of the given matrix
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto transpose(const Matrix3<T>& mat) -> Matrix3<T> {
     Matrix3<T> dst = mat;
     scalar::kernel_transpose_inplace_mat3<T>(dst.elements());
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto tranposeInPlace(Matrix3<T>& mat) -> void {  // NOLINT
     scalar::kernel_transpose_inplace_mat3<T>(mat.elements());
 }
 
 /// Returns the trace (sum of diagonal elements) of the matrix
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto trace(const Matrix3<T>& mat) -> T {
     return scalar::kernel_trace_mat3<T>(mat.elements());
 }
 
 /// Returns the determinant of the matrix
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto determinant(const Matrix3<T>& mat) -> T {
     return scalar::kernel_determinant_mat3<T>(mat.elements());
 }
 
 /// Returns the inverse of the matrix
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto inverse(const Matrix3<T>& mat) -> Matrix3<T> {
     Matrix3<T> dst;
     scalar::kernel_inverse_mat3<T>(dst.elements(), mat.elements());
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator+(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -193,7 +190,7 @@ MATH3D_INLINE auto operator+(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator-(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -201,7 +198,7 @@ MATH3D_INLINE auto operator-(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(double scale, const Matrix3<T>& mat)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -210,7 +207,7 @@ MATH3D_INLINE auto operator*(double scale, const Matrix3<T>& mat)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix3<T>& mat, double scale)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -219,7 +216,7 @@ MATH3D_INLINE auto operator*(const Matrix3<T>& mat, double scale)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -228,7 +225,7 @@ MATH3D_INLINE auto operator*(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix3<T>& lhs_mat,
                              const Vector3<T>& rhs_vec) -> Vector3<T> {
     Vector3<T> dst;
@@ -237,7 +234,7 @@ MATH3D_INLINE auto operator*(const Matrix3<T>& lhs_mat,
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto hadamard(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
@@ -246,19 +243,19 @@ MATH3D_INLINE auto hadamard(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator==(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> bool {
     return scalar::kernel_compare_eq_mat3<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator!=(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> bool {
     return !scalar::kernel_compare_eq_mat3<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 auto operator<<(std::ostream& output_stream, const Matrix3<T>& src)
     -> std::ostream& {
     constexpr int PRECISION_DIGITS = 10;
@@ -272,7 +269,7 @@ auto operator<<(std::ostream& output_stream, const Matrix3<T>& src)
     return output_stream;
 }
 
-template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
+template <typename T>
 auto operator>>(std::istream& input_stream, Matrix3<T>& dst) -> std::istream& {
     // Based on ignition-math implementation https://bit.ly/3MPgPcW
     input_stream.setf(std::ios_base::skipws);

--- a/include/math/mat4_t.hpp
+++ b/include/math/mat4_t.hpp
@@ -199,11 +199,8 @@ auto Matrix4<T>::Zeros() -> Matrix4<T> {
 //                       Matrix Methods implementation                        //
 // ***************************************************************************//
 
-template <typename T>
-using SFINAE_MAT4_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
-
 /// \brief Returns the transpose of the given matrix
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto transpose(const Matrix4<T>& mat) -> Matrix4<T> {
     Matrix4<T> dst = mat;
     scalar::kernel_transpose_inplace_mat4<T>(dst.elements());
@@ -211,25 +208,25 @@ MATH3D_INLINE auto transpose(const Matrix4<T>& mat) -> Matrix4<T> {
 }
 
 /// \brief Transposes the given matrix in-place
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto transposeInPlace(Matrix4<T>& mat) -> void {  // NOLINT
     scalar::kernel_transpose_inplace_mat4<T>(mat.elements());
 }
 
 /// Returns the trace (sum of diagonal elements) of the matrix
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto trace(const Matrix4<T>& mat) -> T {
     return scalar::kernel_trace_mat4<T>(mat.elements());
 }
 
 /// Returns the determinant of the matrix
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto determinant(const Matrix4<T>& mat) -> T {
     return scalar::kernel_determinant_mat4<T>(mat.elements());
 }
 
 /// Returns the inverse of the matrix
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto inverse(const Matrix4<T>& mat) -> Matrix4<T> {
     Matrix4<T> dst;
     scalar::kernel_inverse_mat4<T>(dst.elements(), mat.elements());
@@ -237,7 +234,7 @@ MATH3D_INLINE auto inverse(const Matrix4<T>& mat) -> Matrix4<T> {
 }
 
 /// \brief Returns the matrix-sum of the two given matrices
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator+(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -252,7 +249,7 @@ MATH3D_INLINE auto operator+(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
 }
 
 /// \brief Returns the matrix-difference of the two given matrices
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator-(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -267,7 +264,7 @@ MATH3D_INLINE auto operator-(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
 }
 
 /// \brief Returns the scaled version of the given matrix by the given factor
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(double scale, const Matrix4<T>& mat)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -285,7 +282,7 @@ MATH3D_INLINE auto operator*(double scale, const Matrix4<T>& mat)
 }
 
 /// \brief Returns the scaled version of the given matrix by the given factor
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix4<T>& mat, double scale)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -303,7 +300,7 @@ MATH3D_INLINE auto operator*(const Matrix4<T>& mat, double scale)
 }
 
 /// \brief Returns the matrix product of the two given matrices
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -319,7 +316,7 @@ MATH3D_INLINE auto operator*(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
 }
 
 /// \brief Returns the matrix-vector product of the given operands
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Matrix4<T>& lhs_mat,
                              const Vector4<T>& rhs_vec) -> Vector4<T> {
     Vector4<T> dst;
@@ -337,7 +334,7 @@ MATH3D_INLINE auto operator*(const Matrix4<T>& lhs_mat,
 }
 
 /// \brief Returns the element-wise product of the two given matrices
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto hadamard(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> Matrix4<T> {
     Matrix4<T> dst;
@@ -355,20 +352,20 @@ MATH3D_INLINE auto hadamard(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
 }
 
 /// \brief Checks if two given matrices are "equal" (within epsilon margin)
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator==(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> bool {
     return scalar::kernel_compare_eq_mat4<T>(lhs.elements(), rhs.elements());
 }
 
 /// \brief Checks if two given matrices are "not equal" (within epsilon margin)
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator!=(const Matrix4<T>& lhs, const Matrix4<T>& rhs)
     -> bool {
     return !scalar::kernel_compare_eq_mat4<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 auto operator<<(std::ostream& output_stream, const Matrix4<T>& src)
     -> std::ostream& {
     constexpr int PRECISION_DIGITS = 10;
@@ -384,7 +381,7 @@ auto operator<<(std::ostream& output_stream, const Matrix4<T>& src)
     return output_stream;
 }
 
-template <typename T, SFINAE_MAT4_GUARD<T> = nullptr>
+template <typename T>
 auto operator>>(std::istream& input_stream, Matrix4<T>& dst) -> std::istream& {
     // Based on ignition-math implementation https://bit.ly/3MPgPcW
     input_stream.setf(std::ios_base::skipws);

--- a/include/math/quat_t.hpp
+++ b/include/math/quat_t.hpp
@@ -17,11 +17,8 @@ namespace math {
 //                       Quaternion Methods and Operators                     //
 // ***************************************************************************//
 
-template <typename T>
-using SFINAE_QUAT_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
-
 /// Returns the square of the length of the given quaternion
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto squareNorm(const Quaternion<T>& quat) -> T {
 #if defined(MATH3D_AVX_ENABLED)
     return avx::kernel_length_square_quat<T>(quat.elements());
@@ -33,7 +30,7 @@ MATH3D_INLINE auto squareNorm(const Quaternion<T>& quat) -> T {
 }
 
 /// Returns the length of the given quaternion
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto norm(const Quaternion<T>& quat) -> T {
 #if defined(MATH3D_AVX_ENABLED)
     return avx::kernel_length_quat<T>(quat.elements());
@@ -45,7 +42,7 @@ MATH3D_INLINE auto norm(const Quaternion<T>& quat) -> T {
 }
 
 /// Returns a normalized version of the given quaternion
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto normalize(const Quaternion<T>& quat) -> Quaternion<T> {
     Quaternion<T> quat_normalized = quat;
 #if defined(MATH3D_AVX_ENABLED)
@@ -59,7 +56,7 @@ MATH3D_INLINE auto normalize(const Quaternion<T>& quat) -> Quaternion<T> {
 }
 
 /// Normalizes in place the given quaternion
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto normalize_in_place(Quaternion<T>& quat) -> void {  // NOLINT
 #if defined(MATH3D_AVX_ENABLED)
     avx::kernel_normalize_in_place_quat<T>(quat.elements());
@@ -70,7 +67,7 @@ MATH3D_INLINE auto normalize_in_place(Quaternion<T>& quat) -> void {  // NOLINT
 #endif
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator+(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     -> Quaternion<T> {
     Quaternion<T> dst;
@@ -84,7 +81,7 @@ MATH3D_INLINE auto operator+(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator-(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     -> Quaternion<T> {
     Quaternion<T> dst;
@@ -98,7 +95,7 @@ MATH3D_INLINE auto operator-(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(double scale, const Quaternion<T>& quat)
     -> Quaternion<T> {
     Quaternion<T> dst;
@@ -115,7 +112,7 @@ MATH3D_INLINE auto operator*(double scale, const Quaternion<T>& quat)
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Quaternion<T>& quat, double scale)
     -> Quaternion<T> {
     Quaternion<T> dst;
@@ -132,7 +129,7 @@ MATH3D_INLINE auto operator*(const Quaternion<T>& quat, double scale)
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     -> Quaternion<T> {
     Quaternion<T> dst;
@@ -141,7 +138,7 @@ MATH3D_INLINE auto operator*(const Quaternion<T>& lhs, const Quaternion<T>& rhs)
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto conjugate(const Quaternion<T>& quat) -> Quaternion<T> {
     Quaternion<T> dst = quat;
     dst.x() = -dst.x();
@@ -150,7 +147,7 @@ MATH3D_INLINE auto conjugate(const Quaternion<T>& quat) -> Quaternion<T> {
     return dst;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto inverse(const Quaternion<T>& quat) -> Quaternion<T> {
     auto q_conj = conjugate<T>(quat);
     auto length_sq = squareNorm<T>(quat);
@@ -158,7 +155,7 @@ MATH3D_INLINE auto inverse(const Quaternion<T>& quat) -> Quaternion<T> {
     return q_inv;
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto rotate(const Quaternion<T>& quat, const Vector3<T>& vec)
     -> Vector3<T> {
     // We use the form f(p) = q * p * q ^-1
@@ -169,19 +166,19 @@ MATH3D_INLINE auto rotate(const Quaternion<T>& quat, const Vector3<T>& vec)
     return Vector3<T>(quat_qpqinv.x(), quat_qpqinv.y(), quat_qpqinv.z());
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator*(const Quaternion<T>& quat, const Vector3<T>& vec)
     -> Vector3<T> {
     return ::math::rotate<T>(quat, vec);
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator==(const Quaternion<T>& lhs,
                               const Quaternion<T>& rhs) -> bool {
     return scalar::kernel_compare_eq_quat<T>(lhs.elements(), rhs.elements());
 }
 
-template <typename T, SFINAE_QUAT_GUARD<T> = nullptr>
+template <typename T>
 MATH3D_INLINE auto operator!=(const Quaternion<T>& lhs,
                               const Quaternion<T>& rhs) -> bool {
     return !scalar::kernel_compare_eq_quat<T>(lhs.elements(), rhs.elements());


### PR DESCRIPTION
This PR removes the usage of `SFINAE` from most of the math types we currently have. These checks we did with `SFINAE` can be replaced by a simple `static_assert,` as we were only checking for the type T to be a scalar type.